### PR TITLE
Simplifying the name of the binary releases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,9 +25,7 @@ archives:
     name_template: >-
       {{ .ProjectName }}_
       {{- title .Os }}_
-      {{- if eq .Arch "amd64" }}x86_64
-      {{- else if eq .Arch "386" }}i386
-      {{- else }}{{ .Arch }}{{ end }}
+      {{- .Arch }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
     # use zip for windows archives
     format_overrides:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,7 +21,7 @@ builds:
 
 archives:
   - formats: [tar.gz]
-    # this name template makes the OS and Arch compatible with the results of `uname`.
+    # this name template makes the OS and Arch compatible with the platform and architecture names from NodeJS.
     name_template: >-
       {{ .ProjectName }}_
       {{- .Os }}_

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,7 +24,7 @@ archives:
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_
-      {{- title .Os }}_
+      {{- .Os }}_
       {{- .Arch }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
     # use zip for windows archives


### PR DESCRIPTION
Relates to https://github.com/opentofu/vscode-opentofu/pull/7

To make it easier to consume the binaries from tofu-ls in `vscode-opentofu`, this PR is aiming to simplify that:

<img width="1264" alt="Screenshot 2025-05-16 at 13 27 29" src="https://github.com/user-attachments/assets/0931e8aa-d6ff-44e1-bf40-568eff5a7c23" />

We're mainly making the `architecture` name as it's and `os` is not capitalized anymore.

## Target Release

1.10.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/tofu-ls/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: -->

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
