### PR TITLE
Check for OS and Arch before the schema fetching, decrease number of embeded providers to 100

### DIFF
--- a/internal/features/modules/hooks/module_version_test.go
+++ b/internal/features/modules/hooks/module_version_test.go
@@ -75,7 +75,7 @@ func TestHooks_RegistryModuleVersions(t *testing.T) {
 		}
 		http.Error(w, fmt.Sprintf("unexpected request: %q", r.RequestURI), 400)
 	}))
-	regClient.BaseURL = srv.URL
+	regClient.BaseAPIURL = srv.URL
 	t.Cleanup(srv.Close)
 
 	h := &Hooks{

--- a/internal/features/modules/jobs/schema_test.go
+++ b/internal/features/modules/jobs/schema_test.go
@@ -83,7 +83,7 @@ func TestGetModuleDataFromRegistry_singleModule(t *testing.T) {
 		}
 		http.Error(w, fmt.Sprintf("unexpected request: %q", r.RequestURI), 400)
 	}))
-	regClient.BaseURL = srv.URL
+	regClient.BaseAPIURL = srv.URL
 	t.Cleanup(srv.Close)
 
 	err = GetModuleDataFromRegistry(ctx, regClient, ms, gs.RegistryModules, modPath)
@@ -160,7 +160,7 @@ func TestGetModuleDataFromRegistry_submodule(t *testing.T) {
 		}
 		http.Error(w, fmt.Sprintf("unexpected request: %q", r.RequestURI), 400)
 	}))
-	regClient.BaseURL = srv.URL
+	regClient.BaseAPIURL = srv.URL
 	t.Cleanup(srv.Close)
 
 	err = GetModuleDataFromRegistry(ctx, regClient, ms, gs.RegistryModules, modPath)
@@ -241,7 +241,7 @@ func TestGetModuleDataFromRegistry_unreliableInputs(t *testing.T) {
 		}
 		http.Error(w, fmt.Sprintf("unexpected request: %q", r.RequestURI), 400)
 	}))
-	regClient.BaseURL = srv.URL
+	regClient.BaseAPIURL = srv.URL
 	t.Cleanup(srv.Close)
 
 	err = GetModuleDataFromRegistry(ctx, regClient, ms, gs.RegistryModules, modPath)
@@ -337,7 +337,7 @@ func TestGetModuleDataFromRegistry_moduleNotFound(t *testing.T) {
 		}
 		http.Error(w, fmt.Sprintf("unexpected request: %q", r.RequestURI), 400)
 	}))
-	regClient.BaseURL = srv.URL
+	regClient.BaseAPIURL = srv.URL
 	t.Cleanup(srv.Close)
 
 	err = GetModuleDataFromRegistry(ctx, regClient, ms, gs.RegistryModules, modPath)
@@ -444,7 +444,7 @@ func TestGetModuleDataFromRegistry_apiTimeout(t *testing.T) {
 		}
 		http.Error(w, fmt.Sprintf("unexpected request: %q", r.RequestURI), 400)
 	}))
-	regClient.BaseURL = srv.URL
+	regClient.BaseAPIURL = srv.URL
 	t.Cleanup(srv.Close)
 
 	err = GetModuleDataFromRegistry(ctx, regClient, ms, gs.RegistryModules, modPath)

--- a/internal/langserver/handlers/session_mock_test.go
+++ b/internal/langserver/handlers/session_mock_test.go
@@ -84,7 +84,7 @@ func (ms *mockSession) new(srvCtx context.Context) session.Session {
 	}
 	ms.registryServer.Start()
 
-	regClient.BaseURL = ms.registryServer.URL
+	regClient.BaseAPIURL = ms.registryServer.URL
 
 	svc := &service{
 		logger:             testLogger(),

--- a/internal/registry/module.go
+++ b/internal/registry/module.go
@@ -87,7 +87,7 @@ func (c Client) GetModuleData(ctx context.Context, addr tfaddr.Module, cons vers
 
 	ctx = httptrace.WithClientTrace(ctx, otelhttptrace.NewClientTrace(ctx, otelhttptrace.WithoutSubSpans()))
 
-	url := fmt.Sprintf("%s/v1/modules/%s/%s/%s/%s", c.BaseURL,
+	url := fmt.Sprintf("%s/v1/modules/%s/%s/%s/%s", c.BaseAPIURL,
 		addr.Package.Namespace,
 		addr.Package.Name,
 		addr.Package.TargetSystem,
@@ -142,7 +142,7 @@ func (c Client) GetModuleVersions(ctx context.Context, addr tfaddr.Module) (vers
 	ctx, span := otel.Tracer(tracerName).Start(ctx, "registry:GetModuleVersions")
 	defer span.End()
 
-	url := fmt.Sprintf("%s/v1/modules/%s/%s/%s/versions", c.BaseURL,
+	url := fmt.Sprintf("%s/v1/modules/%s/%s/%s/versions", c.BaseAPIURL,
 		addr.Package.Namespace,
 		addr.Package.Name,
 		addr.Package.TargetSystem)

--- a/internal/registry/module_test.go
+++ b/internal/registry/module_test.go
@@ -41,7 +41,7 @@ func TestGetModuleData(t *testing.T) {
 		}
 		http.Error(w, fmt.Sprintf("unexpected request: %q", r.RequestURI), 400)
 	}))
-	client.BaseURL = srv.URL
+	client.BaseAPIURL = srv.URL
 	t.Cleanup(srv.Close)
 
 	data, err := client.GetModuleData(ctx, addr, cons)
@@ -146,7 +146,7 @@ func TestGetMatchingModuleVersion(t *testing.T) {
 		}
 		http.Error(w, fmt.Sprintf("unexpected request: %q", r.RequestURI), 400)
 	}))
-	client.BaseURL = srv.URL
+	client.BaseAPIURL = srv.URL
 	t.Cleanup(srv.Close)
 
 	v, err := client.GetMatchingModuleVersion(ctx, addr, cons)
@@ -180,7 +180,7 @@ func TestCancellationThroughContext(t *testing.T) {
 		}
 		http.Error(w, fmt.Sprintf("unexpected request: %q", r.RequestURI), 400)
 	}))
-	client.BaseURL = srv.URL
+	client.BaseAPIURL = srv.URL
 	t.Cleanup(srv.Close)
 
 	_, err = client.GetMatchingModuleVersion(ctx, addr, cons)

--- a/internal/registry/provider.go
+++ b/internal/registry/provider.go
@@ -37,9 +37,17 @@ type providerVersionResponse struct {
 	Versions []ProviderVersion `json:"versions"`
 }
 
-func (c Client) ListProviders() ([]Provider, error) {
+func (c Client) ListPopularProviders(limit int) ([]Provider, error) {
+	providers, err := c.listPopularProvidersRaw(limit)
+	if err != nil {
+		return nil, err
+	}
+	return filterUnsupportedProviders(providers)
+}
+
+func (c Client) listPopularProvidersRaw(limit int) ([]Provider, error) {
 	var providers []Provider
-	url := fmt.Sprintf("%s/top/providers?limit=100", c.BaseURL)
+	url := fmt.Sprintf("%s/top/providers?limit=%d", c.BaseURL, limit)
 	resp, err := http.Get(url)
 	if err != nil {
 		return nil, err
@@ -61,7 +69,7 @@ func (c Client) ListProviders() ([]Provider, error) {
 	}
 	providers = append(providers, response...)
 
-	return filterUnsupportedProviders(providers)
+	return providers, err
 }
 
 // filterUnsupportedProviders filters out providers that are not supported

--- a/internal/registry/provider_test.go
+++ b/internal/registry/provider_test.go
@@ -9,6 +9,9 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -16,7 +19,81 @@ import (
 	tfaddr "github.com/opentofu/registry-address"
 )
 
-func TestListProviders(t *testing.T) {
+func TestListPopularProvidersFiltered(t *testing.T) {
+	client := NewClient()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.RequestURI == "/top/providers?limit=5" {
+			w.Write([]byte(`[
+				{"addr":"hashicorp/aws","version":"v1.0.0","popularity":10291},
+				{"addr":"hashicorp/azurerm","version":"v1.0.0","popularity":4722},
+			    {"addr":"hashicorp/google","version":"v1.0.0","popularity":2466},
+				{"addr":"telmate/proxmox","version":"v1.0.0","popularity":2399},
+				{"addr":"hashicorp/unsupported","version":"v1.0.0","popularity":100}
+			]`))
+			return
+		}
+		if strings.HasPrefix(r.RequestURI, "/v1/providers/") && !strings.Contains(r.RequestURI, "unsupported") {
+			w.Write([]byte(fmt.Sprintf(`{
+				"versions": [
+					{
+						"version": "1.0.0",
+						"protocols": ["5.0"],
+						"platforms": [
+							{"os": "%s", "arch": "%s"}
+						]
+					}
+				]
+			}`, runtime.GOOS, runtime.GOARCH)))
+			return
+		} else if strings.Contains(r.RequestURI, "unsupported") {
+			w.Write([]byte(`{
+				"versions": [
+					{
+						"version": "v1.0.0",
+						"protocols": ["5.0"],
+						"platforms": [
+						]
+					}
+				]
+			}`))
+			return
+		}
+
+		http.Error(w, fmt.Sprintf("unexpected request: %q", r.RequestURI), 400)
+	}))
+	client.BaseAPIURL = srv.URL
+	client.BaseRegistryURL = srv.URL
+	t.Cleanup(srv.Close)
+
+	providers, err := client.ListPopularProviders(5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedProviders := []Provider{
+		{Addr: "hashicorp/aws", Version: "v1.0.0"},
+		{Addr: "hashicorp/azurerm", Version: "v1.0.0"},
+		{Addr: "hashicorp/google", Version: "v1.0.0"},
+		{Addr: "telmate/proxmox", Version: "v1.0.0"},
+	}
+	sortFn := func(a, b Provider) int {
+		if a.Addr < b.Addr {
+			return -1
+		}
+		if a.Addr > b.Addr {
+			return 1
+		}
+		return 0
+	}
+
+	slices.SortFunc(providers, sortFn)
+	slices.SortFunc(expectedProviders, sortFn)
+	if diff := cmp.Diff(expectedProviders, providers); diff != "" {
+		t.Fatalf("unexpected providers: %s", diff)
+	}
+}
+
+func TestListPopularProviders(t *testing.T) {
 	client := NewClient()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -32,8 +109,7 @@ func TestListProviders(t *testing.T) {
 
 		http.Error(w, fmt.Sprintf("unexpected request: %q", r.RequestURI), 400)
 	}))
-	client.BaseURL = srv.URL
-	client.ProviderPageSize = 2
+	client.BaseAPIURL = srv.URL
 	t.Cleanup(srv.Close)
 
 	providers, err := client.listPopularProvidersRaw(4)
@@ -53,7 +129,7 @@ func TestListProviders(t *testing.T) {
 }
 
 func TestGetLatestProviderVersion(t *testing.T) {
-	client := NewRegistryClient()
+	client := NewClient()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.RequestURI == "/v1/providers/hashicorp/aws/versions" {
@@ -85,12 +161,13 @@ func TestGetLatestProviderVersion(t *testing.T) {
 
 		http.Error(w, fmt.Sprintf("unexpected request: %q", r.RequestURI), 400)
 	}))
-	client.BaseURL = srv.URL
+	client.BaseAPIURL = srv.URL
+	client.BaseRegistryURL = srv.URL
 	t.Cleanup(srv.Close)
 
 	pAddr := tfaddr.NewProvider(tfaddr.DefaultProviderRegistryHost, "hashicorp", "aws")
 
-	resp, err := client.CheckProviderVersionSupported(pAddr)
+	resp, err := client.checkProviderVersionSupported(pAddr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/registry/provider_test.go
+++ b/internal/registry/provider_test.go
@@ -20,7 +20,7 @@ func TestListProviders(t *testing.T) {
 	client := NewClient()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.RequestURI == "/top/providers?limit=500" {
+		if r.RequestURI == "/top/providers?limit=4" {
 			w.Write([]byte(`[
 				{"addr":"hashicorp/aws","version":"v6.0.0-beta1","popularity":10291},
 				{"addr":"hashicorp/azurerm","version":"v4.27.0","popularity":4722},
@@ -36,7 +36,7 @@ func TestListProviders(t *testing.T) {
 	client.ProviderPageSize = 2
 	t.Cleanup(srv.Close)
 
-	providers, err := client.ListProviders()
+	providers, err := client.listPopularProvidersRaw(4)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -21,10 +21,10 @@ const (
 )
 
 type Client struct {
-	BaseURL          string
-	Timeout          time.Duration
-	ProviderPageSize int
-	httpClient       *http.Client
+	BaseAPIURL      string
+	BaseRegistryURL string
+	Timeout         time.Duration
+	httpClient      *http.Client
 }
 
 func NewClient() Client {
@@ -33,22 +33,9 @@ func NewClient() Client {
 	client.Transport = otelhttp.NewTransport(client.Transport)
 
 	return Client{
-		BaseURL:          defaultBaseURL,
-		Timeout:          defaultTimeout,
-		ProviderPageSize: 100,
-		httpClient:       client,
-	}
-}
-
-func NewRegistryClient() Client {
-	client := cleanhttp.DefaultClient()
-	client.Timeout = defaultTimeout
-	client.Transport = otelhttp.NewTransport(client.Transport)
-
-	return Client{
-		BaseURL:          registryBaseURL,
-		Timeout:          defaultTimeout,
-		ProviderPageSize: 100,
-		httpClient:       client,
+		BaseAPIURL:      defaultBaseURL,
+		BaseRegistryURL: registryBaseURL,
+		Timeout:         defaultTimeout,
+		httpClient:      client,
 	}
 }

--- a/internal/schemas/gen/gen.go
+++ b/internal/schemas/gen/gen.go
@@ -52,6 +52,8 @@ func main() {
 	}())
 }
 
+const NumberOfProviders = 100
+
 func gen() error {
 	ctx := context.Background()
 
@@ -63,7 +65,7 @@ func gen() error {
 
 	client := registry.NewClient()
 	log.Println("fetching from registry")
-	listOfProviders, err := client.ListProviders()
+	listOfProviders, err := client.ListPopularProviders(NumberOfProviders)
 	if err != nil {
 		return err
 	}

--- a/internal/schemas/gen/gen.go
+++ b/internal/schemas/gen/gen.go
@@ -190,7 +190,8 @@ func gen() error {
 	registryClient := registry.NewRegistryClient()
 
 	var workerWg sync.WaitGroup
-	workerCount := runtime.NumCPU()
+	// We should have high worker count since the main bottleneck is the network
+	workerCount := 30
 	log.Printf("worker count: %d", workerCount)
 	workerWg.Add(workerCount)
 	for i := 1; i <= workerCount; i++ {
@@ -339,12 +340,6 @@ func schemaForProvider(ctx context.Context, client registry.Client, input Inputs
 		}
 		if !pv.Equal(input.ProviderVersion) {
 			return nil, fmt.Errorf("expected provider version %s to match %s", pv, pVersion)
-		}
-
-		lpv, err := client.CheckProviderVersionSupported(input.Provider.Addr)
-
-		if !registry.ProviderVersionSupportsOsAndArch(*input.ProviderVersion, lpv.Versions, runtime.GOOS, runtime.GOARCH) {
-			return nil, fmt.Errorf("version %s does not support %s/%s", input.ProviderVersion, runtime.GOOS, runtime.GOARCH)
 		}
 	}
 

--- a/internal/schemas/gen/gen.go
+++ b/internal/schemas/gen/gen.go
@@ -190,8 +190,6 @@ func gen() error {
 		close(providerChan)
 	}()
 
-	registryClient := registry.NewRegistryClient()
-
 	var workerWg sync.WaitGroup
 	// We should have high worker count since the main bottleneck is the network
 	workerCount := 30
@@ -202,7 +200,7 @@ func gen() error {
 		go func(i int) {
 			defer workerWg.Done()
 			for input := range providerChan {
-				details, err := schemaForProvider(ctx, registryClient, input)
+				details, err := schemaForProvider(ctx, input)
 
 				if err != nil {
 					log.Printf("%s: %s", input.Provider.Addr.ForDisplay(), err)
@@ -238,7 +236,7 @@ type Outputs struct {
 	InitElapsedTime time.Duration
 }
 
-func schemaForProvider(ctx context.Context, client registry.Client, input Inputs) (*Outputs, error) {
+func schemaForProvider(ctx context.Context, input Inputs) (*Outputs, error) {
 	var pVersion *version.Version
 	pVersion = input.CoreVersion
 


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
In this PR, I've mainly addressed 3 points:
- Increase worker count for schema fetching since the network speed is the bottleneck for the operation.
- Move the support check for Arch and OS just after fetching the provider list. As expected, downloading provider binaries with tofu init separately is the most time-consuming part
- Reduce the number of embedded schemas to 100, which reduces the binary size to ~ 30 MB; otherwise, the binary gets too big (~50 MB with 500), and generating it takes a lot of time.

Additionally, I've refactored the registry client to have a single constructor and contain both registry and API URL, to avoid calling the wrong method on a wrongly initialized client.

## Target Release

0.0.1

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/tofu-ls/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: -->

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
