### PR TITLE
ioutil is deprecated - replace by io and os packages

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -7,13 +7,13 @@ package cmd
 
 import (
 	"flag"
-	"io/ioutil"
+	"io"
 	"strings"
 )
 
 func defaultFlagSet(cmdName string) *flag.FlagSet {
 	f := flag.NewFlagSet(cmdName, flag.ContinueOnError)
-	f.SetOutput(ioutil.Discard)
+	f.SetOutput(io.Discard)
 
 	// Set the default Usage to empty
 	f.Usage = func() {}

--- a/internal/filesystem/filesystem.go
+++ b/internal/filesystem/filesystem.go
@@ -8,8 +8,8 @@ package filesystem
 import (
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -36,7 +36,7 @@ func NewFilesystem(docStore DocumentStore) *Filesystem {
 	return &Filesystem{
 		osFs:     osFs{},
 		docStore: docStore,
-		logger:   log.New(ioutil.Discard, "", 0),
+		logger:   log.New(io.Discard, "", 0),
 	}
 }
 

--- a/internal/filesystem/filesystem_test.go
+++ b/internal/filesystem/filesystem_test.go
@@ -6,8 +6,8 @@
 package filesystem
 
 import (
+	"io"
 	"io/fs"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -345,5 +345,5 @@ func testLogger() *log.Logger {
 		return log.New(os.Stdout, "", log.LstdFlags|log.Lshortfile)
 	}
 
-	return log.New(ioutil.Discard, "", 0)
+	return log.New(io.Discard, "", 0)
 }

--- a/internal/langserver/diagnostics/diagnostics_test.go
+++ b/internal/langserver/diagnostics/diagnostics_test.go
@@ -7,7 +7,7 @@ package diagnostics
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"log"
 	"testing"
 
@@ -16,7 +16,7 @@ import (
 	"github.com/opentofu/tofu-ls/internal/terraform/ast"
 )
 
-var discardLogger = log.New(ioutil.Discard, "", 0)
+var discardLogger = log.New(io.Discard, "", 0)
 
 func TestDiags_Closes(t *testing.T) {
 	n := NewNotifier(noopNotifier{}, discardLogger)

--- a/internal/langserver/handlers/session_mock_test.go
+++ b/internal/langserver/handlers/session_mock_test.go
@@ -7,7 +7,7 @@ package handlers
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -116,7 +116,7 @@ func testLogger() *log.Logger {
 		return log.New(os.Stdout, "", log.LstdFlags|log.Lshortfile)
 	}
 
-	return log.New(ioutil.Discard, "", 0)
+	return log.New(io.Discard, "", 0)
 }
 
 func (ms *mockSession) stop() {

--- a/internal/langserver/langserver.go
+++ b/internal/langserver/langserver.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -48,7 +47,7 @@ func NewLangServer(srvCtx context.Context, sf session.SessionFactory) *langServe
 
 	return &langServer{
 		srvCtx:     srvCtx,
-		logger:     log.New(ioutil.Discard, "", 0),
+		logger:     log.New(io.Discard, "", 0),
 		srvOptions: opts,
 		newSession: sf,
 	}

--- a/internal/langserver/notifier/notifier_test.go
+++ b/internal/langserver/notifier/notifier_test.go
@@ -8,7 +8,7 @@ package notifier
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"sync"
 	"testing"
@@ -61,5 +61,5 @@ func testLogger() *log.Logger {
 	if testing.Verbose() {
 		return log.Default()
 	}
-	return log.New(ioutil.Discard, "", 0)
+	return log.New(io.Discard, "", 0)
 }

--- a/internal/protocol/gen/gen.go
+++ b/internal/protocol/gen/gen.go
@@ -10,7 +10,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -51,7 +51,7 @@ func main() {
 		log.Fatalf("status code: %d (%s)", resp.StatusCode, url)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Fatalf("failed reading body: %s", err)
 	}

--- a/internal/registry/module.go
+++ b/internal/registry/module.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptrace"
 	"sort"
@@ -105,7 +105,7 @@ func (c Client) GetModuleData(ctx context.Context, addr tfaddr.Module, cons vers
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
-		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, err
 		}
@@ -161,7 +161,7 @@ func (c Client) GetModuleVersions(ctx context.Context, addr tfaddr.Module) (vers
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
-		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -8,7 +8,7 @@ package scheduler
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"log"
 
 	"github.com/opentofu/tofu-ls/internal/job"
@@ -35,7 +35,7 @@ type JobStorage interface {
 }
 
 func NewScheduler(jobStorage JobStorage, parallelism int, priority job.JobPriority) *Scheduler {
-	discardLogger := log.New(ioutil.Discard, "", 0)
+	discardLogger := log.New(io.Discard, "", 0)
 
 	return &Scheduler{
 		logger:      discardLogger,

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -8,7 +8,7 @@ package scheduler
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -476,5 +476,5 @@ func testLogger() *log.Logger {
 		return log.New(os.Stdout, "", log.LstdFlags|log.Lshortfile)
 	}
 
-	return log.New(ioutil.Discard, "", 0)
+	return log.New(io.Discard, "", 0)
 }

--- a/internal/state/jobs_test.go
+++ b/internal/state/jobs_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -213,7 +213,7 @@ func testLogger() *log.Logger {
 		return log.New(os.Stdout, "", log.LstdFlags|log.Lshortfile)
 	}
 
-	return log.New(ioutil.Discard, "", 0)
+	return log.New(io.Discard, "", 0)
 }
 
 func TestJobStore_DequeueJobsForDir(t *testing.T) {

--- a/internal/terraform/datadir/module_manifest.go
+++ b/internal/terraform/datadir/module_manifest.go
@@ -9,7 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -161,7 +161,7 @@ func (mm *ModuleManifest) ContainsLocalModule(path string) bool {
 }
 
 func ParseModuleManifestFromFile(path string) (*ModuleManifest, error) {
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
https://pkg.go.dev/io/ioutil#pkg-overview

"Deprecated: As of Go 1.16, the same functionality is now provided by package [io](https://pkg.go.dev/io) or package [os](https://pkg.go.dev/os), and those implementations should be preferred in new code. See the specific function documentation for details."

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/tofu-ls/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: -->

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
