### PR TITLE
flaky init tests on modules

### DIFF
--- a/internal/features/modules/modules_feature.go
+++ b/internal/features/modules/modules_feature.go
@@ -70,7 +70,8 @@ func (f *ModulesFeature) Start(ctx context.Context) {
 	ctx, cancelFunc := context.WithCancel(ctx)
 	f.stopFunc = cancelFunc
 
-	discover := f.eventbus.OnDiscover("feature.modules", nil)
+	discoverDone := make(chan struct{}, 10)
+	discover := f.eventbus.OnDiscover("feature.modules", discoverDone)
 
 	didOpenDone := make(chan struct{}, 10)
 	didOpen := f.eventbus.OnDidOpen("feature.modules", didOpenDone)
@@ -87,6 +88,7 @@ func (f *ModulesFeature) Start(ctx context.Context) {
 			case discover := <-discover:
 				// TODO? collect errors
 				f.discover(discover.Path, discover.Files)
+				discoverDone <- struct{}{}
 			case didOpen := <-didOpen:
 				// TODO? collect errors
 				f.didOpen(didOpen.Context, didOpen.Dir, didOpen.LanguageID)

--- a/internal/features/rootmodules/root_modules_feature.go
+++ b/internal/features/rootmodules/root_modules_feature.go
@@ -68,7 +68,8 @@ func (f *RootModulesFeature) Start(ctx context.Context) {
 	ctx, cancelFunc := context.WithCancel(ctx)
 	f.stopFunc = cancelFunc
 
-	discover := f.eventbus.OnDiscover("feature.rootmodules", nil)
+	discoverDone := make(chan struct{}, 10)
+	discover := f.eventbus.OnDiscover("feature.rootmodules", discoverDone)
 
 	didOpenDone := make(chan struct{}, 10)
 	didOpen := f.eventbus.OnDidOpen("feature.rootmodules", didOpenDone)
@@ -85,6 +86,7 @@ func (f *RootModulesFeature) Start(ctx context.Context) {
 			case discover := <-discover:
 				// TODO? collect errors
 				f.discover(discover.Path, discover.Files)
+				discoverDone <- struct{}{}
 			case didOpen := <-didOpen:
 				// TODO? collect errors
 				f.didOpen(didOpen.Context, didOpen.Dir)


### PR DESCRIPTION
I wasn't able to reproduce this locally, but this is an attempt to wait for all the modules to be discovered before moving forward. I used the same pattern that is being used by other type of events (you can check the files modified).

The flaky test is this one (I've seen multiple times in this repo): 
https://github.com/opentofu/tofu-ls/actions/runs/15115910838/job/42486401987

The check is done here:
https://github.com/opentofu/tofu-ls/blob/main/internal/langserver/handlers/initialize_test.go#L568

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/tofu-ls/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: -->

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
