### PR TITLE
update docs links to use search.opentofu.org

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -143,7 +143,7 @@ The data is sourced from the declared modules inside the files of the module.
       "source_addr": "terraform-aws-modules/vpc/aws",
       "version": "3.11.0",
       "source_type": "tfregistry",
-      "docs_link": "https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/3.11.0",
+      "docs_link": "https://search.opentofu.org/module/terraform-aws-modules/vpc/aws/v3.11.0",
       "dependent_modules": []
     }
   ]
@@ -175,7 +175,7 @@ installed version.
     "registry.opentofu.org/hashicorp/aws": {
       "display_name": "hashicorp/aws",
       "version_constraint": "~> 3.64.0",
-      "docs_link": "https://registry.opentofu.org/providers/hashicorp/aws/latest"
+      "docs_link": "https://search.opentofu.org/provider/hashicorp/aws/latest"
     }
   },
   "installed_providers": {

--- a/internal/langserver/handlers/command/module_calls.go
+++ b/internal/langserver/handlers/command/module_calls.go
@@ -129,7 +129,7 @@ func getModuleDocumentationLink(ctx context.Context, sourceAddr tfmod.ModuleSour
 	if !ok || registryAddr.Package.Host != "registry.opentofu.org" {
 		return "", nil
 	}
-	rawURL := fmt.Sprintf(`https://registry.opentofu.org/module/%s/latest`, registryAddr.Package.ForRegistryProtocol())
+	rawURL := fmt.Sprintf(`https://search.opentofu.org/module/%s/latest`, registryAddr.Package.ForRegistryProtocol())
 
 	u, err := docsURL(ctx, rawURL, "workspace/executeCommand/module.calls")
 	if err != nil {

--- a/internal/langserver/handlers/command/module_calls_test.go
+++ b/internal/langserver/handlers/command/module_calls_test.go
@@ -66,7 +66,7 @@ func Test_parseModuleRecords(t *testing.T) {
 					SourceAddr:       "terraform-aws-modules/ec2-instance/aws",
 					Version:          "2.12.0",
 					SourceType:       "tfregistry",
-					DocsLink:         "https://registry.opentofu.org/module/terraform-aws-modules/ec2-instance/aws/latest",
+					DocsLink:         "https://search.opentofu.org/module/terraform-aws-modules/ec2-instance/aws/latest",
 					DependentModules: []moduleCall{},
 				},
 				{
@@ -74,7 +74,7 @@ func Test_parseModuleRecords(t *testing.T) {
 					SourceAddr:       "terraform-aws-modules/eks/aws",
 					Version:          "17.20.0",
 					SourceType:       "tfregistry",
-					DocsLink:         "https://registry.opentofu.org/module/terraform-aws-modules/eks/aws/latest",
+					DocsLink:         "https://search.opentofu.org/module/terraform-aws-modules/eks/aws/latest",
 					DependentModules: []moduleCall{},
 				},
 				{
@@ -125,7 +125,7 @@ func Test_parseModuleRecords_v1_1(t *testing.T) {
 					SourceAddr:       "terraform-aws-modules/ec2-instance/aws",
 					Version:          "2.12.0",
 					SourceType:       "tfregistry",
-					DocsLink:         "https://registry.opentofu.org/module/terraform-aws-modules/ec2-instance/aws/latest",
+					DocsLink:         "https://search.opentofu.org/module/terraform-aws-modules/ec2-instance/aws/latest",
 					DependentModules: []moduleCall{},
 				},
 			},

--- a/internal/langserver/handlers/command/module_providers.go
+++ b/internal/langserver/handlers/command/module_providers.go
@@ -82,7 +82,7 @@ func getProviderDocumentationLink(ctx context.Context, provider tfaddr.Provider)
 		return "", nil
 	}
 
-	rawURL := fmt.Sprintf(`https://registry.opentofu.org/provider/%s/latest`, provider.ForDisplay())
+	rawURL := fmt.Sprintf(`https://search.opentofu.org/provider/%s/latest`, provider.ForDisplay())
 
 	u, err := docsURL(ctx, rawURL, "workspace/executeCommand/module.providers")
 	if err != nil {

--- a/internal/langserver/handlers/execute_command_module_providers_test.go
+++ b/internal/langserver/handlers/execute_command_module_providers_test.go
@@ -174,12 +174,12 @@ func TestLangServer_workspaceExecuteCommand_moduleProviders_basic(t *testing.T) 
 				"registry.opentofu.org/hashicorp/aws": {
 					"display_name": "hashicorp/aws",
 					"version_constraint":"1.2.3",
-					"docs_link": "https://registry.opentofu.org/provider/hashicorp/aws/latest"
+					"docs_link": "https://search.opentofu.org/provider/hashicorp/aws/latest"
 				},
 				"registry.opentofu.org/hashicorp/google": {
 					"display_name": "hashicorp/google",
 					"version_constraint": "\u003e= 2.0.0",
-					"docs_link": "https://registry.opentofu.org/provider/hashicorp/google/latest"
+					"docs_link": "https://search.opentofu.org/provider/hashicorp/google/latest"
 				}
 			},
 			"installed_providers":{


### PR DESCRIPTION
Docs links are currently pointing to `registry.opentofu.org` but our docs are hosted at `search.opentofu.org`. This PR is changing the url and fixing the tests.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/tofu-ls/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: -->

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
