### PR TITLE
use OpenTofu's Registry API on Modules

### DIFF
--- a/internal/features/modules/hooks/module_version_test.go
+++ b/internal/features/modules/hooks/module_version_test.go
@@ -69,7 +69,7 @@ func TestHooks_RegistryModuleVersions(t *testing.T) {
 
 	regClient := registry.NewClient()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.RequestURI == "/v1/modules/terraform-aws-modules/vpc/aws/versions" {
+		if r.RequestURI == "/registry/docs/modules/terraform-aws-modules/vpc/aws/index.json" {
 			w.Write([]byte(moduleVersionsMockResponse))
 			return
 		}

--- a/internal/features/modules/jobs/schema_test.go
+++ b/internal/features/modules/jobs/schema_test.go
@@ -73,11 +73,11 @@ func TestGetModuleDataFromRegistry_singleModule(t *testing.T) {
 
 	regClient := registry.NewClient()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.RequestURI == "/v1/modules/puppetlabs/deployment/ec/versions" {
+		if r.RequestURI == "/registry/docs/modules/puppetlabs/deployment/ec/index.json" {
 			w.Write([]byte(puppetModuleVersionsMockResponse))
 			return
 		}
-		if r.RequestURI == "/v1/modules/puppetlabs/deployment/ec/0.0.8" {
+		if r.RequestURI == "/registry/docs/modules/puppetlabs/deployment/ec/v0.0.8/index.json" {
 			w.Write([]byte(puppetModuleDataMockResponse))
 			return
 		}
@@ -150,11 +150,11 @@ func TestGetModuleDataFromRegistry_submodule(t *testing.T) {
 
 	regClient := registry.NewClient()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.RequestURI == "/v1/modules/puppetlabs/deployment/ec/versions" {
+		if r.RequestURI == "/registry/docs/modules/puppetlabs/deployment/ec/index.json" {
 			w.Write([]byte(puppetModuleVersionsMockResponse))
 			return
 		}
-		if r.RequestURI == "/v1/modules/puppetlabs/deployment/ec/0.0.8" {
+		if r.RequestURI == "/registry/docs/modules/puppetlabs/deployment/ec/v0.0.8/index.json" {
 			w.Write([]byte(puppetModuleDataMockResponse))
 			return
 		}
@@ -227,15 +227,15 @@ func TestGetModuleDataFromRegistry_unreliableInputs(t *testing.T) {
 
 	regClient := registry.NewClient()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.RequestURI == "/v1/modules/cloudposse/label/null/versions" {
+		if r.RequestURI == "/registry/docs/modules/cloudposse/label/null/index.json" {
 			w.Write([]byte(labelNullModuleVersionsMockResponse))
 			return
 		}
-		if r.RequestURI == "/v1/modules/cloudposse/label/null/0.25.0" {
+		if r.RequestURI == "/registry/docs/modules/cloudposse/label/null/v0.25.0/index.json" {
 			w.Write([]byte(labelNullModuleDataOldMockResponse))
 			return
 		}
-		if r.RequestURI == "/v1/modules/cloudposse/label/null/0.26.0" {
+		if r.RequestURI == "/registry/docs/modules/cloudposse/label/null/v0.26.0/index.json" {
 			w.Write([]byte(labelNullModuleDataNewMockResponse))
 			return
 		}
@@ -323,15 +323,15 @@ func TestGetModuleDataFromRegistry_moduleNotFound(t *testing.T) {
 
 	regClient := registry.NewClient()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.RequestURI == "/v1/modules/puppetlabs/deployment/ec/versions" {
+		if r.RequestURI == "/registry/docs/modules/puppetlabs/deployment/ec/index.json" {
 			w.Write([]byte(puppetModuleVersionsMockResponse))
 			return
 		}
-		if r.RequestURI == "/v1/modules/puppetlabs/deployment/ec/0.0.8" {
+		if r.RequestURI == "/registry/docs/modules/puppetlabs/deployment/ec/v0.0.8/index.json" {
 			w.Write([]byte(puppetModuleDataMockResponse))
 			return
 		}
-		if r.RequestURI == "/v1/modules/terraform-aws-modules/eks/aws/versions" {
+		if r.RequestURI == "/registry/docs/modules/terraform-aws-modules/eks/aws/index.json" {
 			http.Error(w, `{"errors":["Not Found"]}`, 404)
 			return
 		}
@@ -429,15 +429,15 @@ func TestGetModuleDataFromRegistry_apiTimeout(t *testing.T) {
 	regClient := registry.NewClient()
 	regClient.Timeout = 500 * time.Millisecond
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.RequestURI == "/v1/modules/puppetlabs/deployment/ec/versions" {
+		if r.RequestURI == "/registry/docs/modules/puppetlabs/deployment/ec/index.json" {
 			w.Write([]byte(puppetModuleVersionsMockResponse))
 			return
 		}
-		if r.RequestURI == "/v1/modules/puppetlabs/deployment/ec/0.0.8" {
+		if r.RequestURI == "/registry/docs/modules/puppetlabs/deployment/ec/v0.0.8/index.json" {
 			w.Write([]byte(puppetModuleDataMockResponse))
 			return
 		}
-		if r.RequestURI == "/v1/modules/terraform-aws-modules/eks/aws/versions" {
+		if r.RequestURI == "/registry/docs/modules/terraform-aws-modules/eks/aws/index.json" {
 			// trigger timeout
 			time.Sleep(1 * time.Second)
 			return

--- a/internal/registry/module.go
+++ b/internal/registry/module.go
@@ -87,7 +87,7 @@ func (c Client) GetModuleData(ctx context.Context, addr tfaddr.Module, cons vers
 
 	ctx = httptrace.WithClientTrace(ctx, otelhttptrace.NewClientTrace(ctx, otelhttptrace.WithoutSubSpans()))
 
-	url := fmt.Sprintf("%s/v1/modules/%s/%s/%s/%s", c.BaseAPIURL,
+	url := fmt.Sprintf("%s/registry/docs/modules/%s/%s/%s/v%s/index.json", c.BaseAPIURL,
 		addr.Package.Namespace,
 		addr.Package.Name,
 		addr.Package.TargetSystem,
@@ -142,7 +142,7 @@ func (c Client) GetModuleVersions(ctx context.Context, addr tfaddr.Module) (vers
 	ctx, span := otel.Tracer(tracerName).Start(ctx, "registry:GetModuleVersions")
 	defer span.End()
 
-	url := fmt.Sprintf("%s/v1/modules/%s/%s/%s/versions", c.BaseAPIURL,
+	url := fmt.Sprintf("%s/registry/docs/modules/%s/%s/%s/index.json", c.BaseAPIURL,
 		addr.Package.Namespace,
 		addr.Package.Name,
 		addr.Package.TargetSystem)

--- a/internal/registry/module_test.go
+++ b/internal/registry/module_test.go
@@ -31,11 +31,11 @@ func TestGetModuleData(t *testing.T) {
 	client := NewClient()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.RequestURI == "/v1/modules/puppetlabs/deployment/ec/versions" {
+		if r.RequestURI == "/registry/docs/modules/puppetlabs/deployment/ec/index.json" {
 			w.Write([]byte(moduleVersionsMockResponse))
 			return
 		}
-		if r.RequestURI == "/v1/modules/puppetlabs/deployment/ec/0.0.8" {
+		if r.RequestURI == "/registry/docs/modules/puppetlabs/deployment/ec/v0.0.8/index.json" {
 			w.Write([]byte(moduleDataMockResponse))
 			return
 		}
@@ -140,7 +140,7 @@ func TestGetMatchingModuleVersion(t *testing.T) {
 	client := NewClient()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.RequestURI == "/v1/modules/puppetlabs/deployment/ec/versions" {
+		if r.RequestURI == "/registry/docs/modules/puppetlabs/deployment/ec/index.json" {
 			w.Write([]byte(moduleVersionsMockResponse))
 			return
 		}
@@ -174,7 +174,7 @@ func TestCancellationThroughContext(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(500 * time.Millisecond)
-		if r.RequestURI == "/v1/modules/puppetlabs/deployment/ec/versions" {
+		if r.RequestURI == "/registry/docs/modules/puppetlabs/deployment/ec/index.json" {
 			w.Write([]byte(moduleVersionsMockResponse))
 			return
 		}


### PR DESCRIPTION
Instead of using TF's Registry URL format for retrieving module info, this PR is pointing to OpenTofu's API for retrieving data for the modules.

Example of an API call: https://api.opentofu.org/registry/docs/modules/terraform-aws-modules/vpc/aws/index.json

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/tofu-ls/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: -->

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
