### PR TITLE
use OpenTofu's Registry API on Providers

### DIFF
--- a/internal/registry/provider.go
+++ b/internal/registry/provider.go
@@ -8,14 +8,15 @@ package registry
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/go-version"
-	tfaddr "github.com/opentofu/registry-address"
 	"io"
 	"log"
 	"net/http"
 	"runtime"
 	"sync"
 	"sync/atomic"
+
+	"github.com/hashicorp/go-version"
+	tfaddr "github.com/opentofu/registry-address"
 )
 
 type Provider struct {
@@ -138,7 +139,7 @@ func (c Client) filterUnsupportedProviders(providers []Provider) ([]Provider, er
 }
 
 func (c Client) checkProviderVersionSupported(pAddr tfaddr.Provider) (*providerVersionResponse, error) {
-	url := fmt.Sprintf("%s/v1/providers/%s/%s/versions", c.BaseRegistryURL, pAddr.Namespace, pAddr.Type)
+	url := fmt.Sprintf("%s/registry/docs/providers/%s/%s/index.json", c.BaseRegistryURL, pAddr.Namespace, pAddr.Type)
 	resp, err := http.Get(url)
 	if err != nil {
 		return nil, err

--- a/internal/registry/provider_test.go
+++ b/internal/registry/provider_test.go
@@ -33,7 +33,7 @@ func TestListPopularProvidersFiltered(t *testing.T) {
 			]`))
 			return
 		}
-		if strings.HasPrefix(r.RequestURI, "/v1/providers/") && !strings.Contains(r.RequestURI, "unsupported") {
+		if strings.HasPrefix(r.RequestURI, "/registry/docs/providers/") && !strings.Contains(r.RequestURI, "unsupported") {
 			w.Write([]byte(fmt.Sprintf(`{
 				"versions": [
 					{
@@ -132,7 +132,7 @@ func TestGetLatestProviderVersion(t *testing.T) {
 	client := NewClient()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.RequestURI == "/v1/providers/hashicorp/aws/versions" {
+		if r.RequestURI == "/registry/docs/providers/hashicorp/aws/index.json" {
 			w.Write([]byte(`{
 			"versions": [
 			{


### PR DESCRIPTION
Instead of using TF's Registry URL format for retrieving provider info, this PR is pointing to OpenTofu's API for retrieving data for the providers.

Example of API: http://api.opentofu.org/registry/docs/providers/hashicorp/aws/index.json

- [x] I have read the [contribution guide](https://github.com/opentofu/tofu-ls/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: -->

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
