### PR TITLE
Using mock version responses from OpenTofu's API

### DIFF
--- a/internal/features/modules/hooks/module_version_test.go
+++ b/internal/features/modules/hooks/module_version_test.go
@@ -24,24 +24,41 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
+// moduleVersionsMockResponse represents the shortened response from https://api.opentofu.org/registry/docs/modules/terraform-aws-modules/vpc/aws/index.json
 var moduleVersionsMockResponse = `{
-	"modules": [
-	  {
-		"source": "terraform-aws-modules/vpc/aws",
-		"versions": [
-		  {
-			"version": "0.0.1"
-		  },
-		  {
-			"version": "2.0.24"
-		  },
-		  {
-			"version": "1.33.7"
-		  }
-		]
-	  }
-	]
-  }`
+  "addr": {
+    "display": "terraform-aws-modules/vpc/aws",
+    "namespace": "terraform-aws-modules",
+    "name": "vpc",
+    "target": "aws"
+  },
+  "description": "Terraform module to create AWS VPC resources 🇺🇦",
+  "versions": [
+    {
+      "id": "v5.21.0",
+      "published": "2025-04-21T23:55:13Z"
+    },
+    {
+      "id": "v2.72.0",
+      "published": "2021-02-22T19:00:52Z"
+    },
+    {
+      "id": "v1.0.0",
+      "published": "2017-09-12T15:53:29Z"
+    }
+  ],
+  "is_blocked": false,
+  "popularity": 3080,
+  "fork_count": 4525,
+  "fork_of": {
+    "display": "//",
+    "namespace": "",
+    "name": "",
+    "target": ""
+  },
+  "upstream_popularity": 0,
+  "upstream_fork_count": 0
+}`
 
 func TestHooks_RegistryModuleVersions(t *testing.T) {
 	ctx := context.Background()
@@ -108,21 +125,21 @@ func TestHooks_RegistryModuleVersions(t *testing.T) {
 
 	expectedCandidates := []decoder.Candidate{
 		{
-			Label:         `"2.0.24"`,
+			Label:         `"5.21.0"`,
 			Kind:          lang.StringCandidateKind,
-			RawInsertText: `"2.0.24"`,
+			RawInsertText: `"5.21.0"`,
 			SortText:      "  0",
 		},
 		{
-			Label:         `"1.33.7"`,
+			Label:         `"2.72.0"`,
 			Kind:          lang.StringCandidateKind,
-			RawInsertText: `"1.33.7"`,
+			RawInsertText: `"2.72.0"`,
 			SortText:      "  1",
 		},
 		{
-			Label:         `"0.0.1"`,
+			Label:         `"1.0.0"`,
 			Kind:          lang.StringCandidateKind,
-			RawInsertText: `"0.0.1"`,
+			RawInsertText: `"1.0.0"`,
 			SortText:      "  2",
 		},
 	}

--- a/internal/features/modules/jobs/schema_mock_responses.go
+++ b/internal/features/modules/jobs/schema_mock_responses.go
@@ -12,141 +12,60 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-// puppetModuleVersionsMockResponse represents response from https://registry.terraform.io/v1/modules/puppetlabs/deployment/ec/versions
+// puppetModuleVersionsMockResponse represents the response from https://api.opentofu.org/registry/docs/modules/puppetlabs/deployment/ec/index.json
 var puppetModuleVersionsMockResponse = `{
-  "modules": [
+  "addr": {
+    "display": "puppetlabs/deployment/ec",
+    "namespace": "puppetlabs",
+    "name": "deployment",
+    "target": "ec"
+  },
+  "description": "",
+  "versions": [
     {
-      "source": "puppetlabs/deployment/ec",
-      "versions": [
-        {
-          "version": "0.0.5",
-          "root": {
-            "providers": [
-              {
-                "name": "ec",
-                "namespace": "",
-                "source": "elastic/ec",
-                "version": "0.2.1"
-              }
-            ],
-            "dependencies": []
-          },
-          "submodules": []
-        },
-        {
-          "version": "0.0.6",
-          "root": {
-            "providers": [
-              {
-                "name": "ec",
-                "namespace": "",
-                "source": "elastic/ec",
-                "version": "0.2.1"
-              }
-            ],
-            "dependencies": []
-          },
-          "submodules": []
-        },
-        {
-          "version": "0.0.8",
-          "root": {
-            "providers": [
-              {
-                "name": "ec",
-                "namespace": "",
-                "source": "elastic/ec",
-                "version": "0.2.1"
-              }
-            ],
-            "dependencies": []
-          },
-          "submodules": []
-        },
-        {
-          "version": "0.0.2",
-          "root": {
-            "providers": [
-              {
-                "name": "ec",
-                "namespace": "",
-                "source": "elastic/ec",
-                "version": "0.2.1"
-              }
-            ],
-            "dependencies": []
-          },
-          "submodules": []
-        },
-        {
-          "version": "0.0.1",
-          "root": {
-            "providers": [],
-            "dependencies": []
-          },
-          "submodules": [
-            {
-              "path": "modules/ec-deployment",
-              "providers": [
-                {
-                  "name": "ec",
-                  "namespace": "",
-                  "source": "elastic/ec",
-                  "version": "0.2.1"
-                }
-              ],
-              "dependencies": []
-            }
-          ]
-        },
-        {
-          "version": "0.0.4",
-          "root": {
-            "providers": [
-              {
-                "name": "ec",
-                "namespace": "",
-                "source": "elastic/ec",
-                "version": "0.2.1"
-              }
-            ],
-            "dependencies": []
-          },
-          "submodules": []
-        },
-        {
-          "version": "0.0.3",
-          "root": {
-            "providers": [
-              {
-                "name": "ec",
-                "namespace": "",
-                "source": "elastic/ec",
-                "version": "0.2.1"
-              }
-            ],
-            "dependencies": []
-          },
-          "submodules": []
-        },
-        {
-          "version": "0.0.7",
-          "root": {
-            "providers": [
-              {
-                "name": "ec",
-                "namespace": "",
-                "source": "elastic/ec",
-                "version": "0.2.1"
-              }
-            ],
-            "dependencies": []
-          },
-          "submodules": []
-        }
-      ]
+      "id": "v0.0.8",
+      "published": "2021-08-05T00:26:01Z"
+    },
+    {
+      "id": "v0.0.7",
+      "published": "2021-08-03T19:57:07Z"
+    },
+    {
+      "id": "v0.0.6",
+      "published": "2021-08-03T19:47:41Z"
+    },
+    {
+      "id": "v0.0.5",
+      "published": "2021-08-03T18:56:01Z"
+    },
+    {
+      "id": "v0.0.4",
+      "published": "2021-08-03T18:39:44Z"
+    },
+    {
+      "id": "v0.0.3",
+      "published": "2021-08-02T21:54:06Z"
+    },
+    {
+      "id": "v0.0.2",
+      "published": "2021-08-02T21:48:35Z"
+    },
+    {
+      "id": "v0.0.1",
+      "published": "2021-08-02T21:18:58Z"
     }
-  ]
+  ],
+  "is_blocked": false,
+  "popularity": 0,
+  "fork_count": 0,
+  "fork_of": {
+    "display": "//",
+    "namespace": "",
+    "name": "",
+    "target": ""
+  },
+  "upstream_popularity": 0,
+  "upstream_fork_count": 0
 }`
 
 // puppetModuleDataMockResponse represents response from https://api.opentofu.org/registry/docs/modules/puppetlabs/deployment/ec/v0.0.8/index.json
@@ -273,31 +192,36 @@ var puppetModuleDataMockResponse = `{
 // labelNullModuleVersionsMockResponse represents response for
 // versions of module that suffers from "unreliable" input data, as described in
 // https://github.com/hashicorp/vscode-terraform/issues/1582
-// It is a shortened response from https://registry.terraform.io/v1/modules/cloudposse/label/null/versions
+// It is a shortened response from https://api.opentofu.org/registry/docs/modules/cloudposse/label/null/index.json
 var labelNullModuleVersionsMockResponse = `{
-  "modules": [
+  "addr": {
+    "display": "cloudposse/label/null",
+    "namespace": "cloudposse",
+    "name": "label",
+    "target": "null"
+  },
+  "description": "",
+  "versions": [
     {
-      "source": "cloudposse/label/null",
-      "versions": [
-        {
-          "version": "0.25.0",
-          "root": {
-            "providers": [],
-            "dependencies": []
-          },
-          "submodules": []
-        },
-        {
-          "version": "0.24.0",
-          "root": {
-            "providers": [],
-            "dependencies": []
-          },
-          "submodules": []
-        }
-      ]
+      "id": "v0.25.0",
+      "published": "2021-08-25T17:45:16Z"
+    },
+    {
+      "id": "v0.24.0",
+      "published": "2021-02-04T08:11:56Z"
     }
-  ]
+  ],
+  "is_blocked": false,
+  "popularity": 0,
+  "fork_count": 0,
+  "fork_of": {
+    "display": "//",
+    "namespace": "",
+    "name": "",
+    "target": ""
+  },
+  "upstream_popularity": 0,
+  "upstream_fork_count": 0
 }`
 
 // labelNullModuleDataMockResponse represents response for

--- a/internal/registry/module.go
+++ b/internal/registry/module.go
@@ -50,15 +50,11 @@ type Output struct {
 }
 
 type ModuleVersionsResponse struct {
-	Modules []ModuleVersionsEntry `json:"modules"`
-}
-
-type ModuleVersionsEntry struct {
 	Versions []ModuleVersion `json:"versions"`
 }
 
 type ModuleVersion struct {
-	Version string `json:"version"`
+	Version string `json:"id"`
 }
 
 type ClientError struct {
@@ -173,12 +169,10 @@ func (c Client) GetModuleVersions(ctx context.Context, addr tfaddr.Module) (vers
 	decodeSpan.End()
 
 	var foundVersions version.Collection
-	for _, module := range response.Modules {
-		for _, entry := range module.Versions {
-			ver, err := version.NewVersion(entry.Version)
-			if err == nil {
-				foundVersions = append(foundVersions, ver)
-			}
+	for _, entry := range response.Versions {
+		ver, err := version.NewVersion(entry.Version)
+		if err == nil {
+			foundVersions = append(foundVersions, ver)
 		}
 	}
 	span.AddEvent("registry:foundModuleVersions",

--- a/internal/registry/module_mock_responses_test.go
+++ b/internal/registry/module_mock_responses_test.go
@@ -5,141 +5,60 @@
 
 package registry
 
-// moduleVersionsMockResponse represents response from https://registry.terraform.io/v1/modules/puppetlabs/deployment/ec/versions
+// moduleVersionsMockResponse represents response from https://api.opentofu.org/registry/docs/modules/puppetlabs/deployment/ec/index.json
 var moduleVersionsMockResponse = `{
-  "modules": [
+  "addr": {
+    "display": "puppetlabs/deployment/ec",
+    "namespace": "puppetlabs",
+    "name": "deployment",
+    "target": "ec"
+  },
+  "description": "",
+  "versions": [
     {
-      "source": "puppetlabs/deployment/ec",
-      "versions": [
-        {
-          "version": "0.0.5",
-          "root": {
-            "providers": [
-              {
-                "name": "ec",
-                "namespace": "",
-                "source": "elastic/ec",
-                "version": "0.2.1"
-              }
-            ],
-            "dependencies": []
-          },
-          "submodules": []
-        },
-        {
-          "version": "0.0.6",
-          "root": {
-            "providers": [
-              {
-                "name": "ec",
-                "namespace": "",
-                "source": "elastic/ec",
-                "version": "0.2.1"
-              }
-            ],
-            "dependencies": []
-          },
-          "submodules": []
-        },
-        {
-          "version": "0.0.8",
-          "root": {
-            "providers": [
-              {
-                "name": "ec",
-                "namespace": "",
-                "source": "elastic/ec",
-                "version": "0.2.1"
-              }
-            ],
-            "dependencies": []
-          },
-          "submodules": []
-        },
-        {
-          "version": "0.0.2",
-          "root": {
-            "providers": [
-              {
-                "name": "ec",
-                "namespace": "",
-                "source": "elastic/ec",
-                "version": "0.2.1"
-              }
-            ],
-            "dependencies": []
-          },
-          "submodules": []
-        },
-        {
-          "version": "0.0.1",
-          "root": {
-            "providers": [],
-            "dependencies": []
-          },
-          "submodules": [
-            {
-              "path": "modules/ec-deployment",
-              "providers": [
-                {
-                  "name": "ec",
-                  "namespace": "",
-                  "source": "elastic/ec",
-                  "version": "0.2.1"
-                }
-              ],
-              "dependencies": []
-            }
-          ]
-        },
-        {
-          "version": "0.0.4",
-          "root": {
-            "providers": [
-              {
-                "name": "ec",
-                "namespace": "",
-                "source": "elastic/ec",
-                "version": "0.2.1"
-              }
-            ],
-            "dependencies": []
-          },
-          "submodules": []
-        },
-        {
-          "version": "0.0.3",
-          "root": {
-            "providers": [
-              {
-                "name": "ec",
-                "namespace": "",
-                "source": "elastic/ec",
-                "version": "0.2.1"
-              }
-            ],
-            "dependencies": []
-          },
-          "submodules": []
-        },
-        {
-          "version": "0.0.7",
-          "root": {
-            "providers": [
-              {
-                "name": "ec",
-                "namespace": "",
-                "source": "elastic/ec",
-                "version": "0.2.1"
-              }
-            ],
-            "dependencies": []
-          },
-          "submodules": []
-        }
-      ]
+      "id": "v0.0.8",
+      "published": "2021-08-05T00:26:01Z"
+    },
+    {
+      "id": "v0.0.7",
+      "published": "2021-08-03T19:57:07Z"
+    },
+    {
+      "id": "v0.0.6",
+      "published": "2021-08-03T19:47:41Z"
+    },
+    {
+      "id": "v0.0.5",
+      "published": "2021-08-03T18:56:01Z"
+    },
+    {
+      "id": "v0.0.4",
+      "published": "2021-08-03T18:39:44Z"
+    },
+    {
+      "id": "v0.0.3",
+      "published": "2021-08-02T21:54:06Z"
+    },
+    {
+      "id": "v0.0.2",
+      "published": "2021-08-02T21:48:35Z"
+    },
+    {
+      "id": "v0.0.1",
+      "published": "2021-08-02T21:18:58Z"
     }
-  ]
+  ],
+  "is_blocked": false,
+  "popularity": 0,
+  "fork_count": 0,
+  "fork_of": {
+    "display": "//",
+    "namespace": "",
+    "name": "",
+    "target": ""
+  },
+  "upstream_popularity": 0,
+  "upstream_fork_count": 0
 }`
 
 // moduleDataMockResponse represents response from https://api.opentofu.org/registry/docs/modules/puppetlabs/deployment/ec/v0.0.8/index.json


### PR DESCRIPTION
Autocompletion is broken at the moment because `tofu-ls` is expecting to use Terraform's API data format on the endpoint that is getting the versions, like https://api.opentofu.org/registry/docs/modules/cloudposse/label/null/index.json

This PR is meant to fix the second part of it - first part was fixed [here](https://github.com/opentofu/tofu-ls/pull/56) -  the response for the module versions call.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/tofu-ls/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: -->

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
