### PR TITLE
Command names - opentofu instead of tofu

### DIFF
--- a/internal/langserver/handlers/execute_command.go
+++ b/internal/langserver/handlers/execute_command.go
@@ -26,13 +26,13 @@ func cmdHandlers(svc *service) cmd.Handlers {
 		cmdHandler.RootModulesFeature = svc.features.RootModules
 	}
 	return cmd.Handlers{
-		cmd.Name("rootmodules"):      removedHandler("use module.callers instead"),
-		cmd.Name("module.callers"):   cmdHandler.ModuleCallersHandler,
-		cmd.Name("tofu.init"):        cmdHandler.TofuInitHandler,
-		cmd.Name("tofu.validate"):    cmdHandler.TofuValidateHandler,
-		cmd.Name("module.calls"):     cmdHandler.ModuleCallsHandler,
-		cmd.Name("module.providers"): cmdHandler.ModuleProvidersHandler,
-		cmd.Name("module.tofu"):      cmdHandler.TofuVersionRequestHandler,
+		cmd.Name("rootmodules"):         removedHandler("use module.callers instead"),
+		cmd.Name("module.callers"):      cmdHandler.ModuleCallersHandler,
+		cmd.Name("opentofu.init"):       cmdHandler.TofuInitHandler,
+		cmd.Name("opentotofu.validate"): cmdHandler.TofuValidateHandler,
+		cmd.Name("module.calls"):        cmdHandler.ModuleCallsHandler,
+		cmd.Name("module.providers"):    cmdHandler.ModuleProvidersHandler,
+		cmd.Name("module.opentofu"):     cmdHandler.TofuVersionRequestHandler,
 	}
 }
 

--- a/internal/langserver/handlers/execute_command.go
+++ b/internal/langserver/handlers/execute_command.go
@@ -26,13 +26,13 @@ func cmdHandlers(svc *service) cmd.Handlers {
 		cmdHandler.RootModulesFeature = svc.features.RootModules
 	}
 	return cmd.Handlers{
-		cmd.Name("rootmodules"):         removedHandler("use module.callers instead"),
-		cmd.Name("module.callers"):      cmdHandler.ModuleCallersHandler,
-		cmd.Name("opentofu.init"):       cmdHandler.TofuInitHandler,
-		cmd.Name("opentotofu.validate"): cmdHandler.TofuValidateHandler,
-		cmd.Name("module.calls"):        cmdHandler.ModuleCallsHandler,
-		cmd.Name("module.providers"):    cmdHandler.ModuleProvidersHandler,
-		cmd.Name("module.opentofu"):     cmdHandler.TofuVersionRequestHandler,
+		cmd.Name("rootmodules"):       removedHandler("use module.callers instead"),
+		cmd.Name("module.callers"):    cmdHandler.ModuleCallersHandler,
+		cmd.Name("opentofu.init"):     cmdHandler.TofuInitHandler,
+		cmd.Name("opentofu.validate"): cmdHandler.TofuValidateHandler,
+		cmd.Name("module.calls"):      cmdHandler.ModuleCallsHandler,
+		cmd.Name("module.providers"):  cmdHandler.ModuleProvidersHandler,
+		cmd.Name("module.opentofu"):   cmdHandler.TofuVersionRequestHandler,
 	}
 }
 

--- a/internal/langserver/handlers/execute_command_init_test.go
+++ b/internal/langserver/handlers/execute_command_init_test.go
@@ -71,7 +71,7 @@ func TestLangServer_workspaceExecuteCommand_init_argumentError(t *testing.T) {
 		Method: "workspace/executeCommand",
 		ReqParams: fmt.Sprintf(`{
 		"command": %q
-	}`, cmd.Name("tofu.init"))}, jrpc2.InvalidParams.Err())
+	}`, cmd.Name("opentofu.init"))}, jrpc2.InvalidParams.Err())
 }
 
 func TestLangServer_workspaceExecuteCommand_init_basic(t *testing.T) {
@@ -157,7 +157,7 @@ func TestLangServer_workspaceExecuteCommand_init_basic(t *testing.T) {
 		ReqParams: fmt.Sprintf(`{
 		"command": %q,
 		"arguments": ["uri=%s"]
-	}`, cmd.Name("tofu.init"), tmpDir.URI)}, `{
+	}`, cmd.Name("opentofu.init"), tmpDir.URI)}, `{
 		"jsonrpc": "2.0",
 		"id": 3,
 		"result": null
@@ -247,5 +247,5 @@ func TestLangServer_workspaceExecuteCommand_init_error(t *testing.T) {
 		ReqParams: fmt.Sprintf(`{
 		"command": %q,
 		"arguments": ["uri=%s"]
-	}`, cmd.Name("tofu.init"), testFileURI)}, jrpc2.SystemError.Err())
+	}`, cmd.Name("opentofu.init"), testFileURI)}, jrpc2.SystemError.Err())
 }

--- a/internal/langserver/handlers/execute_command_terraform_version_test.go
+++ b/internal/langserver/handlers/execute_command_terraform_version_test.go
@@ -105,7 +105,7 @@ func TestLangServer_workspaceExecuteCommand_tofuVersion_basic(t *testing.T) {
 		ReqParams: fmt.Sprintf(`{
 		"command": %q,
 		"arguments": ["uri=%s"]
-	}`, cmd.Name("module.tofu"), modUri)}, `{
+	}`, cmd.Name("module.opentofu"), modUri)}, `{
 		"jsonrpc": "2.0",
 		"id": 2,
 		"result": {

--- a/internal/langserver/handlers/execute_command_validate_test.go
+++ b/internal/langserver/handlers/execute_command_validate_test.go
@@ -68,5 +68,5 @@ func TestLangServer_workspaceExecuteCommand_validate_argumentError(t *testing.T)
 		Method: "workspace/executeCommand",
 		ReqParams: fmt.Sprintf(`{
 		"command": %q
-	}`, cmd.Name("tofu.validate"))}, jrpc2.InvalidParams.Err())
+	}`, cmd.Name("opentofu.validate"))}, jrpc2.InvalidParams.Err())
 }


### PR DESCRIPTION
Using "opentofu" as the prefix of the command names. This fixes one bug on VSCode extension. 

Fixes https://github.com/opentofu/vscode-opentofu/pull/12

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/tofu-ls/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: -->

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
