### PR TITLE
point the provider versions URL to OpenTofu's Registry Protocol API

### DIFF
--- a/internal/registry/provider.go
+++ b/internal/registry/provider.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"net/http"
 	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -139,7 +140,7 @@ func (c Client) filterUnsupportedProviders(providers []Provider) ([]Provider, er
 }
 
 func (c Client) checkProviderVersionSupported(pAddr tfaddr.Provider) (*providerVersionResponse, error) {
-	url := fmt.Sprintf("%s/registry/docs/providers/%s/%s/index.json", c.BaseRegistryURL, pAddr.Namespace, pAddr.Type)
+	url := fmt.Sprintf("%s/v1/providers/%s/%s/versions", c.BaseRegistryURL, pAddr.Namespace, pAddr.Type)
 	resp, err := http.Get(url)
 	if err != nil {
 		return nil, err
@@ -165,12 +166,12 @@ func (c Client) checkProviderVersionSupported(pAddr tfaddr.Provider) (*providerV
 
 func ProviderVersionSupportsOsAndArch(pVersion version.Version, providerVersions []ProviderVersion, os, arch string) bool {
 	for _, version := range providerVersions {
-		if version.Version != pVersion.String() {
+		if !strings.Contains(version.Version, pVersion.String()) {
 			continue
 		}
+
 		for _, platform := range version.Platforms {
-			if platform.OS == os &&
-				platform.Arch == arch {
+			if platform.OS == os && platform.Arch == arch {
 				return true
 			}
 		}

--- a/internal/registry/provider_test.go
+++ b/internal/registry/provider_test.go
@@ -32,8 +32,7 @@ func TestListPopularProvidersFiltered(t *testing.T) {
 				{"addr":"hashicorp/unsupported","version":"v1.0.0","popularity":100}
 			]`))
 			return
-		}
-		if strings.HasPrefix(r.RequestURI, "/registry/docs/providers/") && !strings.Contains(r.RequestURI, "unsupported") {
+		} else if !strings.Contains(r.RequestURI, "unsupported") {
 			w.Write([]byte(fmt.Sprintf(`{
 				"versions": [
 					{
@@ -70,6 +69,7 @@ func TestListPopularProvidersFiltered(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	expectedProviders := []Provider{
 		{Addr: "hashicorp/aws", Version: "v1.0.0"},
 		{Addr: "hashicorp/azurerm", Version: "v1.0.0"},
@@ -132,7 +132,7 @@ func TestGetLatestProviderVersion(t *testing.T) {
 	client := NewClient()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.RequestURI == "/registry/docs/providers/hashicorp/aws/index.json" {
+		if r.RequestURI == "/v1/providers/hashicorp/aws/versions" {
 			w.Write([]byte(`{
 			"versions": [
 			{


### PR DESCRIPTION
While using `go generate`, I noticed that the provider fetch mechanism was using the wrong URL. For checking supported platform versions, we need to use `registry.opentofu.org/v1/providers/:namespace/:type/versions`

This PR adjusts that and fixes the tests related to it.

Output while generating after fix:

```
....
2025/05/28 13:41:32 (96/100) Provider dell/redfish version v1.6.0 supports darwin/arm64
2025/05/28 13:41:32 (97/100) Provider dbt-labs/dbtcloud version v1.1.0 supports darwin/arm64
2025/05/28 13:41:32 (98/100) Provider cloudposse/utils version v1.30.0 supports darwin/arm64
2025/05/28 13:41:32 (99/100) Provider stackitcloud/stackit version v0.54.0 supports darwin/arm64
2025/05/28 13:41:32 (100/100) Provider splunk/splunk version v1.4.30 supports darwin/arm64
2025/05/28 13:41:32 Finished filtering providers, found 100 supported providers out of 100
...
```

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/tofu-ls/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: -->

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.
