### PR TITLE
fix: creating a file to prevent race conditions when calling didOpen

### DIFF
--- a/internal/langserver/handlers/workspace_symbol_test.go
+++ b/internal/langserver/handlers/workspace_symbol_test.go
@@ -7,8 +7,11 @@ package handlers
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/opentofu/tofu-ls/internal/document"
 	"github.com/opentofu/tofu-ls/internal/langserver"
 	"github.com/opentofu/tofu-ls/internal/state"
 	"github.com/opentofu/tofu-ls/internal/tofu/exec"
@@ -16,9 +19,20 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+func initializeFiles(t *testing.T, tmpDir document.DirHandle) {
+	t.Helper()
+
+	err := os.WriteFile(filepath.Join(tmpDir.Path(), "second.tf"), []byte("provider \"google\" {}\n"), 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestLangServer_workspace_symbol_basic(t *testing.T) {
 	tmpDir := TempDir(t)
 	InitPluginCache(t, tmpDir.Path())
+
+	initializeFiles(t, tmpDir)
 
 	ss, err := state.NewStateStore()
 	if err != nil {
@@ -167,6 +181,8 @@ func TestLangServer_workspace_symbol_basic(t *testing.T) {
 func TestLangServer_workspace_symbol_missing(t *testing.T) {
 	tmpDir := TempDir(t)
 	InitPluginCache(t, tmpDir.Path())
+
+	initializeFiles(t, tmpDir)
 
 	ss, err := state.NewStateStore()
 	if err != nil {

--- a/internal/langserver/handlers/workspace_symbol_test.go
+++ b/internal/langserver/handlers/workspace_symbol_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+// This function is used to fix flaky tests on Mac OS. This code is based
+// on https://github.com/hashicorp/terraform-ls/pull/1880
 func initializeFiles(t *testing.T, tmpDir document.DirHandle) {
 	t.Helper()
 


### PR DESCRIPTION
Resolves #47

It seems there's a race condition while trying to read the folder on the symbol tests. I'm creating a file to make sure the content is there when the first `didOpen` call is issued, the second file is already there.

This is based at some code on the predecessor `-ls` project. (MPL 2.0 license)

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/tofu-ls/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [ ] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [ ] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: -->

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.
