### PR TITLE
Adds support for additional language IDs - terraform and terraform-vars

### DIFF
--- a/internal/decoder/path_reader.go
+++ b/internal/decoder/path_reader.go
@@ -8,14 +8,14 @@ package decoder
 import (
 	"context"
 	"fmt"
-
 	"github.com/hashicorp/hcl-lang/decoder"
 	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/opentofu/tofu-ls/internal/lsp"
 )
 
 type PathReaderMap map[string]decoder.PathReader
 
-// GlobalPathReader is a PathReader that delegates language specific PathReaders
+// GlobalPathReader is a PathReader that delegates language-specific PathReaders
 // that usually come from features.
 type GlobalPathReader struct {
 	PathReaderMap PathReaderMap
@@ -34,7 +34,9 @@ func (mr *GlobalPathReader) Paths(ctx context.Context) []lang.Path {
 }
 
 func (mr *GlobalPathReader) PathContext(path lang.Path) (*decoder.PathContext, error) {
-	if feature, ok := mr.PathReaderMap[path.LanguageID]; ok {
+	// We need to ensure that we can also read language IDs of 'terraform' and 'terraform-vars' which simply map to 'opentofu' and 'opentofu-vars'
+	id := lsp.ParseLanguageID(path.LanguageID)
+	if feature, ok := mr.PathReaderMap[id.String()]; ok {
 		return feature.PathContext(path)
 	}
 

--- a/internal/features/modules/events.go
+++ b/internal/features/modules/events.go
@@ -19,6 +19,7 @@ import (
 	"github.com/opentofu/tofu-ls/internal/features/modules/ast"
 	"github.com/opentofu/tofu-ls/internal/features/modules/jobs"
 	"github.com/opentofu/tofu-ls/internal/job"
+	"github.com/opentofu/tofu-ls/internal/lsp"
 	"github.com/opentofu/tofu-ls/internal/protocol"
 	"github.com/opentofu/tofu-ls/internal/schemas"
 	globalState "github.com/opentofu/tofu-ls/internal/state"
@@ -53,7 +54,7 @@ func (f *ModulesFeature) didOpen(ctx context.Context, dir document.DirHandle, la
 	// b) the opened file is a module file
 	//
 	// Add to state if language ID matches
-	if languageID == "opentofu" {
+	if lsp.IsValidConfigLanguage(languageID) {
 		err := f.Store.AddIfNotExists(path)
 		if err != nil {
 			return ids, err

--- a/internal/features/modules/jobs/parse.go
+++ b/internal/features/modules/jobs/parse.go
@@ -40,7 +40,7 @@ func ParseModuleConfiguration(ctx context.Context, fs ReadOnlyFS, modStore *stat
 	var diags ast.ModDiags
 	rpcContext := lsctx.DocumentContext(ctx)
 	// Only parse the file that's being changed/opened, unless this is 1st-time parsing
-	if mod.ModuleDiagnosticsState[globalAst.HCLParsingSource] == op.OpStateLoaded && rpcContext.IsDidChangeRequest() && rpcContext.LanguageID == ilsp.OpenTofu.String() {
+	if mod.ModuleDiagnosticsState[globalAst.HCLParsingSource] == op.OpStateLoaded && rpcContext.IsDidChangeRequest() && ilsp.IsValidConfigLanguage(rpcContext.LanguageID) {
 		// the file has already been parsed, so only examine this file and not the whole module
 		err = modStore.SetModuleDiagnosticsState(modPath, globalAst.HCLParsingSource, op.OpStateLoading)
 		if err != nil {

--- a/internal/features/modules/jobs/parse_test.go
+++ b/internal/features/modules/jobs/parse_test.go
@@ -146,7 +146,7 @@ func TestParseModuleConfiguration_ignore_tfvars(t *testing.T) {
 
 	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{
 		Method:     "textDocument/didChange",
-		LanguageID: ilsp.Tfvars.String(),
+		LanguageID: ilsp.OpenTofuVars.String(),
 		URI:        uri.FromPath(fooURI),
 	})
 	err = ParseModuleConfiguration(ctx, testFs, ms, singleFileModulePath)

--- a/internal/features/modules/jobs/validation.go
+++ b/internal/features/modules/jobs/validation.go
@@ -66,7 +66,7 @@ func SchemaModuleValidation(ctx context.Context, modStore *state.ModuleStore, ro
 
 	var rErr error
 	rpcContext := lsctx.DocumentContext(ctx)
-	if rpcContext.Method == "textDocument/didChange" && rpcContext.LanguageID == ilsp.OpenTofu.String() {
+	if rpcContext.Method == "textDocument/didChange" && ilsp.IsValidConfigLanguage(rpcContext.LanguageID) {
 		filename := path.Base(rpcContext.URI)
 		// We only revalidate a single file that changed
 		var fileDiags hcl.Diagnostics

--- a/internal/features/variables/decoder/path_reader.go
+++ b/internal/features/variables/decoder/path_reader.go
@@ -45,7 +45,7 @@ func (pr *PathReader) Paths(ctx context.Context) []lang.Path {
 	for _, record := range variableRecords {
 		paths = append(paths, lang.Path{
 			Path:       record.Path(),
-			LanguageID: ilsp.Tfvars.String(),
+			LanguageID: ilsp.OpenTofuVars.String(),
 		})
 	}
 

--- a/internal/features/variables/events.go
+++ b/internal/features/variables/events.go
@@ -15,6 +15,7 @@ import (
 	"github.com/opentofu/tofu-ls/internal/features/variables/ast"
 	"github.com/opentofu/tofu-ls/internal/features/variables/jobs"
 	"github.com/opentofu/tofu-ls/internal/job"
+	"github.com/opentofu/tofu-ls/internal/lsp"
 	"github.com/opentofu/tofu-ls/internal/protocol"
 	op "github.com/opentofu/tofu-ls/internal/tofu/module/operation"
 )
@@ -45,7 +46,7 @@ func (f *VariablesFeature) didOpen(ctx context.Context, dir document.DirHandle, 
 	// b) the opened file is a variable file
 	//
 	// Add to state if language ID matches
-	if languageID == "opentofu-vars" {
+	if lsp.IsValidVarsLanguage(languageID) {
 		err := f.store.AddIfNotExists(path)
 		if err != nil {
 			return ids, err

--- a/internal/features/variables/jobs/parse.go
+++ b/internal/features/variables/jobs/parse.go
@@ -40,7 +40,7 @@ func ParseVariables(ctx context.Context, fs ReadOnlyFS, varStore *state.Variable
 	var diags ast.VarsDiags
 	rpcContext := lsctx.DocumentContext(ctx)
 	// Only parse the file that's being changed/opened, unless this is 1st-time parsing
-	if mod.VarsDiagnosticsState[globalAst.HCLParsingSource] == op.OpStateLoaded && rpcContext.IsDidChangeRequest() && rpcContext.LanguageID == ilsp.Tfvars.String() {
+	if mod.VarsDiagnosticsState[globalAst.HCLParsingSource] == op.OpStateLoaded && rpcContext.IsDidChangeRequest() && ilsp.IsValidVarsLanguage(rpcContext.LanguageID) {
 		// the file has already been parsed, so only examine this file and not the whole module
 		err = varStore.SetVarsDiagnosticsState(modPath, globalAst.HCLParsingSource, op.OpStateLoading)
 		if err != nil {

--- a/internal/features/variables/jobs/parse_test.go
+++ b/internal/features/variables/jobs/parse_test.go
@@ -66,7 +66,7 @@ func TestParseVariables(t *testing.T) {
 	}
 	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{
 		Method:     "textDocument/didChange",
-		LanguageID: ilsp.Tfvars.String(),
+		LanguageID: ilsp.OpenTofuVars.String(),
 		URI:        uri.FromPath(filePath),
 	})
 	err = ParseVariables(ctx, testFs, vs, singleFileModulePath)

--- a/internal/features/variables/jobs/references.go
+++ b/internal/features/variables/jobs/references.go
@@ -53,7 +53,7 @@ func DecodeVarsReferences(ctx context.Context, varStore *state.VariableStore, mo
 
 	varsDecoder, err := d.Path(lang.Path{
 		Path:       modPath,
-		LanguageID: ilsp.Tfvars.String(),
+		LanguageID: ilsp.OpenTofuVars.String(),
 	})
 	if err != nil {
 		return err

--- a/internal/features/variables/jobs/validation.go
+++ b/internal/features/variables/jobs/validation.go
@@ -75,7 +75,7 @@ func SchemaVariablesValidation(ctx context.Context, varStore *state.VariableStor
 
 	moduleDecoder, err := d.Path(lang.Path{
 		Path:       modPath,
-		LanguageID: ilsp.Tfvars.String(),
+		LanguageID: ilsp.OpenTofuVars.String(),
 	})
 	if err != nil {
 		return err
@@ -83,7 +83,7 @@ func SchemaVariablesValidation(ctx context.Context, varStore *state.VariableStor
 
 	var rErr error
 	rpcContext := lsctx.DocumentContext(ctx)
-	if rpcContext.Method == "textDocument/didChange" && rpcContext.LanguageID == ilsp.Tfvars.String() {
+	if rpcContext.Method == "textDocument/didChange" && ilsp.IsValidVarsLanguage(rpcContext.LanguageID) {
 		filename := path.Base(rpcContext.URI)
 		// We only revalidate a single file that changed
 		var fileDiags hcl.Diagnostics

--- a/internal/features/variables/jobs/validation_test.go
+++ b/internal/features/variables/jobs/validation_test.go
@@ -58,7 +58,7 @@ func TestSchemaVarsValidation_FullModule(t *testing.T) {
 	fs := filesystem.NewFilesystem(gs.DocumentStore)
 	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{
 		Method:     "textDocument/didOpen",
-		LanguageID: ilsp.Tfvars.String(),
+		LanguageID: ilsp.OpenTofuVars.String(),
 		URI:        "file:///test/terraform.tfvars",
 	})
 	err = ParseVariables(ctx, fs, vs, modPath)
@@ -111,7 +111,7 @@ func TestSchemaVarsValidation_SingleFile(t *testing.T) {
 	}
 	ctx = lsctx.WithDocumentContext(ctx, lsctx.Document{
 		Method:     "textDocument/didChange",
-		LanguageID: ilsp.Tfvars.String(),
+		LanguageID: ilsp.OpenTofuVars.String(),
 		URI:        uri.FromPath(filePath),
 	})
 	err = ParseVariables(ctx, fs, vs, modPath)

--- a/internal/langserver/handlers/service.go
+++ b/internal/langserver/handlers/service.go
@@ -540,10 +540,8 @@ func (svc *service) configureSessionDependencies(ctx context.Context, cfgOpts *s
 
 	svc.decoder = decoder.NewDecoder(&idecoder.GlobalPathReader{
 		PathReaderMap: idecoder.PathReaderMap{
-			ilsp.OpenTofu.String():      svc.features.Modules,
-			ilsp.OpenTofuVars.String():  svc.features.Variables,
-			ilsp.Terraform.String():     svc.features.Modules,
-			ilsp.TerraformVars.String(): svc.features.Variables,
+			ilsp.OpenTofu.String():     svc.features.Modules,
+			ilsp.OpenTofuVars.String(): svc.features.Variables,
 		},
 	})
 	decoderContext := idecoder.DecoderContext(ctx)

--- a/internal/langserver/handlers/service.go
+++ b/internal/langserver/handlers/service.go
@@ -540,8 +540,10 @@ func (svc *service) configureSessionDependencies(ctx context.Context, cfgOpts *s
 
 	svc.decoder = decoder.NewDecoder(&idecoder.GlobalPathReader{
 		PathReaderMap: idecoder.PathReaderMap{
-			"opentofu":      svc.features.Modules,
-			"opentofu-vars": svc.features.Variables,
+			ilsp.OpenTofu.String():      svc.features.Modules,
+			ilsp.OpenTofuVars.String():  svc.features.Variables,
+			ilsp.Terraform.String():     svc.features.Modules,
+			ilsp.TerraformVars.String(): svc.features.Variables,
 		},
 	})
 	decoderContext := idecoder.DecoderContext(ctx)

--- a/internal/lsp/language_id.go
+++ b/internal/lsp/language_id.go
@@ -12,15 +12,24 @@ type LanguageID string
 const (
 	OpenTofu     LanguageID = "opentofu"
 	OpenTofuVars LanguageID = "opentofu-vars"
-	// Some editors do not support language ID overrides which makes it difficult to use this language server
-	// We also need to accept language IDs of Terraform in order to circumvent this issue
+	// Terraform - Some editors do not support language ID overrides which makes it difficult to use this language server
+	// We also need to accept language IDs of Terraform to circumvent this issue
 	Terraform     LanguageID = "terraform"
 	TerraformVars LanguageID = "terraform-vars"
 )
 
-// LanguageIDsMatch checks if both IDs are of configuration language or vars language
-func LanguageIDsMatch(a, b string) bool {
-	return a == b || (a == OpenTofu.String() && b == Terraform.String()) || (a == Terraform.String() && b == OpenTofu.String())
+// ParseLanguageID parses a string into a LanguageID
+// We also remap Terraform to OpenTofu and TerraformVars to OpenTofuVars
+// We assume that the language ID is valid or the validation step has been done before parsing
+func ParseLanguageID(id string) LanguageID {
+	switch LanguageID(id) {
+	case Terraform:
+		return OpenTofu
+	case TerraformVars:
+		return OpenTofuVars
+	default:
+		return LanguageID(id)
+	}
 }
 
 func IsValidConfigLanguage(id string) bool {

--- a/internal/lsp/language_id.go
+++ b/internal/lsp/language_id.go
@@ -10,9 +10,36 @@ package lsp
 type LanguageID string
 
 const (
-	OpenTofu LanguageID = "opentofu"
-	Tfvars   LanguageID = "opentofu-vars"
+	OpenTofu     LanguageID = "opentofu"
+	OpenTofuVars LanguageID = "opentofu-vars"
+	// Some editors do not support language ID overrides which makes it difficult to use this language server
+	// We also need to accept language IDs of Terraform in order to circumvent this issue
+	Terraform     LanguageID = "terraform"
+	TerraformVars LanguageID = "terraform-vars"
 )
+
+// LanguageIDsMatch checks if both IDs are of configuration language or vars language
+func LanguageIDsMatch(a, b string) bool {
+	return a == b || (a == OpenTofu.String() && b == Terraform.String()) || (a == Terraform.String() && b == OpenTofu.String())
+}
+
+func IsValidConfigLanguage(id string) bool {
+	switch LanguageID(id) {
+	case OpenTofu, Terraform:
+		return true
+	default:
+		return false
+	}
+}
+
+func IsValidVarsLanguage(id string) bool {
+	switch LanguageID(id) {
+	case OpenTofuVars, TerraformVars:
+		return true
+	default:
+		return false
+	}
+}
 
 func (l LanguageID) String() string {
 	return string(l)


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->
This issue arose while I was working on the USAGE.md ( #48  ) rewrite and testing `tofu-ls` with several different editors.
To facilitate integration with a wide range of editors and IDEs, we add support for the language IDs: 'terraform' and 'terraform-vars'.
Remapping extensions and language names can be a bit cumbersome in some cases, and this change will eliminate the need for it.
In earlier iterations, we modified the language IDs to `opentofu` and `opentofu-vars`. Now we extend the language server to accept the other pair too.
<!-- If your PR resolves an issue, please add it here. -->
## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/tofu-ls/blob/main/.github/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
- [x] If I'm releasing, I have read the [releasing guide](https://github.com/opentofu/tofu-ls/blob/main/.github/RELEASE.md).

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: -->

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
