### PR TITLE
doc(command): follow rename of module.tofu

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -185,7 +185,7 @@ installed version.
 }
 ```
 
-### `module.tofu`
+### `module.opentofu`
 
 Provides information about the tofu binary version for the current module.
 

--- a/internal/langserver/handlers/execute_command.go
+++ b/internal/langserver/handlers/execute_command.go
@@ -33,6 +33,7 @@ func cmdHandlers(svc *service) cmd.Handlers {
 		cmd.Name("module.calls"):     cmdHandler.ModuleCallsHandler,
 		cmd.Name("module.providers"): cmdHandler.ModuleProvidersHandler,
 		cmd.Name("module.opentofu"):  cmdHandler.TofuVersionRequestHandler,
+		cmd.Name("module.tofu"):      removedHandler("use module.opentofu instead"),
 	}
 }
 


### PR DESCRIPTION
In #80, `module.tofu` was renamed to `module.opentofu`, but the documentation was not updated to reflect this change. 
As there exists a mechanism for redirecting deprecated commands, avail ourselves of it.

- **fix(command): docs mismatch for `module.opentofu`**
- **chore(command): skip copy by adjusting types**

<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [X] I have read the [contribution guide](https://github.com/opentofu/tofu-ls/blob/main/.github/CONTRIBUTING.md).
- [X] I have not used an AI coding assistant to create this PR.
- [X] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [X] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
- [X] If I'm releasing, I have read the [releasing guide](https://github.com/opentofu/tofu-ls/blob/main/.github/RELEASE.md).

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: -->

- [X] I have run golangci-lint on my change and receive no errors relevant to my code.
- [X] I have run existing tests to ensure my code doesn't break anything.
- [X] I have added tests for all relevant use cases of my code, and those tests are passing.
- [X] I have only exported functions, variables and structs that should be used from other packages.
- [X] I have added meaningful comments to all exported functions, variables, and structs.
