### PR TITLE
fix: dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,3 @@ updates:
       interval: "daily"
     allow:
       - dependency-name: "github.com/opentofu/*"
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    ignore:
-      - dependency-name: "github.com/opentofu/*"


### PR DESCRIPTION
The `dependabot` configuration is invalid. By talking to @Gogotchuri, we wanted to set up only for `opentofu` repos for now.

So the error was: 

```
Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'. Ecosystem 'gomod' has overlapping directories.
```

This is fixed by removing the other repos that were meant to receive weekly updates.

https://github.com/opentofu/tofu-ls/network/updates

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/tofu-ls/blob/main/.github/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
- [x] If I'm releasing, I have read the [releasing guide](https://github.com/opentofu/tofu-ls/blob/main/.github/RELEASE.md).

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: -->

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.
