### PR TITLE
Generate schema with the provider version

### DIFF
--- a/internal/schemas/gen/gen.go
+++ b/internal/schemas/gen/gen.go
@@ -238,7 +238,7 @@ type Outputs struct {
 
 func schemaForProvider(ctx context.Context, input Inputs) (*Outputs, error) {
 	var pVersion *version.Version
-	pVersion = input.CoreVersion
+	pVersion = input.ProviderVersion
 
 	wd := filepath.Join(input.WorkspacePath,
 		input.Provider.Addr.Hostname.String(),


### PR DESCRIPTION
Resolves #130 

The schema is displaying the OpenTofu version instead of the Provider version. 

Test:

<img width="390" height="180" alt="Screenshot 2025-10-22 at 18 15 02" src="https://github.com/user-attachments/assets/14d4ec3f-5c95-4153-90d3-cc85ce35aa73" />


## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/tofu-ls/blob/main/.github/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
- [x] If I'm releasing, I have read the [releasing guide](https://github.com/opentofu/tofu-ls/blob/main/.github/RELEASE.md).

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: -->

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.
