### PR TITLE
Ensure correct usage of language IDs

### DIFF
--- a/internal/langserver/handlers/code_lens.go
+++ b/internal/langserver/handlers/code_lens.go
@@ -30,7 +30,7 @@ func (svc *service) TextDocumentCodeLens(ctx context.Context, params lsp.CodeLen
 
 	path := lang.Path{
 		Path:       doc.Dir.Path(),
-		LanguageID: doc.LanguageID,
+		LanguageID: string(ilsp.ParseLanguageID(doc.LanguageID)),
 	}
 
 	lenses, err := svc.decoder.CodeLensesForFile(ctx, path, doc.Filename)

--- a/internal/langserver/handlers/did_change.go
+++ b/internal/langserver/handlers/did_change.go
@@ -59,7 +59,7 @@ func (svc *service) TextDocumentDidChange(ctx context.Context, params lsp.DidCha
 	svc.eventBus.DidChange(eventbus.DidChangeEvent{
 		Context:    ctx, // We pass the context for data here
 		Dir:        dh.Dir,
-		LanguageID: doc.LanguageID,
+		LanguageID: string(ilsp.ParseLanguageID(doc.LanguageID)),
 	})
 
 	return nil

--- a/internal/langserver/handlers/go_to_ref_target.go
+++ b/internal/langserver/handlers/go_to_ref_target.go
@@ -14,7 +14,7 @@ import (
 	lsp "github.com/opentofu/tofu-ls/internal/protocol"
 )
 
-func (svc *service) GoToDefinition(ctx context.Context, params lsp.TextDocumentPositionParams) (interface{}, error) {
+func (svc *service) GoToDefinition(ctx context.Context, params lsp.TextDocumentPositionParams) (any, error) {
 	cc, err := ilsp.ClientCapabilities(ctx)
 	if err != nil {
 		return nil, err
@@ -28,7 +28,7 @@ func (svc *service) GoToDefinition(ctx context.Context, params lsp.TextDocumentP
 	return ilsp.RefTargetsToDefinitionLocationLinks(targets, cc.TextDocument.Definition), nil
 }
 
-func (svc *service) GoToDeclaration(ctx context.Context, params lsp.TextDocumentPositionParams) (interface{}, error) {
+func (svc *service) GoToDeclaration(ctx context.Context, params lsp.TextDocumentPositionParams) (any, error) {
 	cc, err := ilsp.ClientCapabilities(ctx)
 	if err != nil {
 		return nil, err
@@ -62,7 +62,7 @@ func (svc *service) goToReferenceTarget(ctx context.Context, params lsp.TextDocu
 
 	path := lang.Path{
 		Path:       doc.Dir.Path(),
-		LanguageID: doc.LanguageID,
+		LanguageID: string(ilsp.ParseLanguageID(doc.LanguageID)),
 	}
 
 	return svc.decoder.ReferenceTargetsForOriginAtPos(path, doc.Filename, pos)

--- a/internal/langserver/handlers/references.go
+++ b/internal/langserver/handlers/references.go
@@ -35,7 +35,7 @@ func (svc *service) References(ctx context.Context, params lsp.ReferenceParams) 
 
 	path := lang.Path{
 		Path:       doc.Dir.Path(),
-		LanguageID: doc.LanguageID,
+		LanguageID: ilsp.ParseLanguageID(doc.LanguageID).String(),
 	}
 	// TODO? maybe kick off indexing of the whole workspace here
 	origins := svc.decoder.ReferenceOriginsTargetingPos(path, doc.Filename, pos)

--- a/internal/langserver/handlers/service.go
+++ b/internal/langserver/handlers/service.go
@@ -620,8 +620,10 @@ func (svc *service) shutdown() {
 	}
 }
 
-const requestCancelled jrpc2.Code = -32800
-const tracerName = "github.com/opentofu/tofu-ls/internal/langserver/handlers"
+const (
+	requestCancelled jrpc2.Code = -32800
+	tracerName                  = "github.com/opentofu/tofu-ls/internal/langserver/handlers"
+)
 
 // handle calls a jrpc2.Func compatible function
 func handle(ctx context.Context, req *jrpc2.Request, fn interface{}) (interface{}, error) {
@@ -690,6 +692,6 @@ func handle(ctx context.Context, req *jrpc2.Request, fn interface{}) (interface{
 func (svc *service) decoderForDocument(_ context.Context, doc *document.Document) (*decoder.PathDecoder, error) {
 	return svc.decoder.Path(lang.Path{
 		Path:       doc.Dir.Path(),
-		LanguageID: doc.LanguageID,
+		LanguageID: string(ilsp.ParseLanguageID(doc.LanguageID)),
 	})
 }


### PR DESCRIPTION
There are currently 5 actions that are not using `ilsp.ParseLanguageID` which causes a language mismatch ("terraform" != "opentofu") and so some items are thrown away (For example, references).

This patch ensures that all references to the document's language ID also goes through `ilsp.ParseLanguageID`

Resolves #127

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/tofu-ls/blob/main/.github/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
- [ ] If I'm releasing, I have read the [releasing guide](https://github.com/opentofu/tofu-ls/blob/main/.github/RELEASE.md).

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: -->

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
