### PR TITLE
Handle cases where modules are not yet initialized

### DIFF
--- a/internal/features/modules/decoder/validations/module_schema_not_loaded.go
+++ b/internal/features/modules/decoder/validations/module_schema_not_loaded.go
@@ -1,0 +1,220 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2024 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validations
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl/v2"
+	tfmod "github.com/opentofu/opentofu-schema/module"
+	"github.com/opentofu/opentofu-schema/registry"
+	tfaddr "github.com/opentofu/registry-address"
+)
+
+// ModuleReader provides access to module state for validation
+type ModuleReader interface {
+	DeclaredModuleCalls(modPath string) (map[string]tfmod.DeclaredModuleCall, error)
+	RegistryModuleMeta(addr tfaddr.Module, cons version.Constraints) (*registry.ModuleData, error)
+	LocalModuleMeta(modPath string) (*tfmod.Meta, error)
+}
+
+// RootModuleReader provides access to root module state
+type RootModuleReader interface {
+	InstalledModulePath(rootPath string, normalizedSource string) (string, bool)
+}
+
+// UnloadedModuleSchemaResult contains diagnostics for modules without schema
+// and the ranges of those modules (for filtering false positive errors).
+type UnloadedModuleSchemaResult struct {
+	// Diagnostics contains "Module schema not loaded" warnings per file
+	Diagnostics lang.DiagnosticsMap
+	// UnloadedRanges contains the ranges of module blocks without schema per file
+	UnloadedRanges map[string][]hcl.Range
+}
+
+// ModuleSchemaNotLoaded checks for module blocks that don't have their schema loaded
+// and returns diagnostics for each one, plus the ranges for filtering.
+func ModuleSchemaNotLoaded(
+	modReader ModuleReader,
+	rootReader RootModuleReader,
+	modPath string,
+) UnloadedModuleSchemaResult {
+	result := UnloadedModuleSchemaResult{
+		Diagnostics:    make(lang.DiagnosticsMap),
+		UnloadedRanges: make(map[string][]hcl.Range),
+	}
+
+	// Get declared module calls
+	declaredCalls, err := modReader.DeclaredModuleCalls(modPath)
+	if err != nil {
+		return result
+	}
+
+	for _, call := range declaredCalls {
+		if hasModuleSchemaLoaded(modReader, rootReader, modPath, call) {
+			continue
+		}
+
+		// Module schema not loaded - emit diagnostic and track range
+		if call.RangePtr != nil {
+			fileName := call.RangePtr.Filename
+
+			headerRange := makeRangeForLine(call.RangePtr.Filename, call.RangePtr.Start.Line)
+
+			d := &hcl.Diagnostic{
+				Severity: hcl.DiagWarning,
+				Summary:  "Module schema not loaded",
+				Detail:   "Run 'tofu init' to download module metadata and enable full validation.",
+				Subject:  headerRange.Ptr(),
+			}
+			result.Diagnostics[fileName] = result.Diagnostics[fileName].Append(d)
+
+			result.UnloadedRanges[fileName] = append(result.UnloadedRanges[fileName], *call.RangePtr)
+		}
+	}
+
+	return result
+}
+
+// FilterDiagnosticsForUnloadedModules removes "Unexpected attribute" diagnostics
+// that fall within module blocks that don't have schema loaded.
+func FilterDiagnosticsForUnloadedModules(diags lang.DiagnosticsMap, unloadedRanges map[string][]hcl.Range) lang.DiagnosticsMap {
+	filtered := make(lang.DiagnosticsMap)
+
+	for filename, fileDiags := range diags {
+		ranges, hasUnloaded := unloadedRanges[filename]
+		if !hasUnloaded {
+			// No unloaded modules in this file, keep all diagnostics
+			filtered[filename] = fileDiags
+			continue
+		}
+
+		// Filter out false positives
+		var kept hcl.Diagnostics
+		for _, diag := range fileDiags {
+			if ShouldFilterDiagnostic(diag, ranges) {
+				continue
+			}
+			kept = append(kept, diag)
+		}
+		if len(kept) > 0 {
+			filtered[filename] = kept
+		}
+	}
+
+	return filtered
+}
+
+// ShouldFilterDiagnostic returns true if the diagnostic should be filtered out
+// because it's a false positive from an unloaded module schema.
+// For now this should only be unexpected attribute errors within unloaded module blocks.
+func ShouldFilterDiagnostic(diag *hcl.Diagnostic, unloadedRanges []hcl.Range) bool {
+	// Only filter "Unexpected attribute" errors
+	if !strings.HasPrefix(diag.Summary, "Unexpected attribute") {
+		return false
+	}
+
+	// Check if the diagnostic falls within an unloaded module block
+	if diag.Subject == nil {
+		return false
+	}
+
+	for _, moduleRange := range unloadedRanges {
+		if rangeContains(moduleRange, *diag.Subject) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// rangeContains checks if outer contains inner (same file, inner starts after outer starts, inner ends before outer ends)
+func rangeContains(outer, inner hcl.Range) bool {
+	if outer.Filename != inner.Filename {
+		return false
+	}
+
+	// Check if inner start is after or at outer start
+	if inner.Start.Line < outer.Start.Line {
+		return false
+	}
+	if inner.Start.Line == outer.Start.Line && inner.Start.Column < outer.Start.Column {
+		return false
+	}
+
+	// Check if inner end is before or at outer end
+	if inner.End.Line > outer.End.Line {
+		return false
+	}
+	if inner.End.Line == outer.End.Line && inner.End.Column > outer.End.Column {
+		return false
+	}
+
+	return true
+}
+
+func hasModuleSchemaLoaded(
+	modReader ModuleReader,
+	rootReader RootModuleReader,
+	modPath string,
+	call tfmod.DeclaredModuleCall,
+) bool {
+	switch sourceAddr := call.SourceAddr.(type) {
+	case tfaddr.Module:
+		// Registry module - first check if installed locally
+		installedDir, ok := rootReader.InstalledModulePath(modPath, sourceAddr.String())
+		if ok {
+			path := filepath.Join(modPath, installedDir)
+			_, err := modReader.LocalModuleMeta(path)
+			return err == nil
+		}
+
+		// Otherwise check if we have cached registry data
+		_, err := modReader.RegistryModuleMeta(sourceAddr, call.Version)
+		return err == nil
+
+	case tfmod.RemoteSourceAddr:
+		// Remote module (git, etc.) - check if installed
+		installedDir, ok := rootReader.InstalledModulePath(modPath, sourceAddr.String())
+		if !ok {
+			return false
+		}
+		path := filepath.Join(modPath, installedDir)
+		_, err := modReader.LocalModuleMeta(path)
+		return err == nil
+
+	case tfmod.LocalSourceAddr:
+		// Local module - check if we can get its metadata
+		path := filepath.Join(modPath, sourceAddr.String())
+		_, err := modReader.LocalModuleMeta(path)
+		return err == nil
+
+	default:
+		// Unknown source type - assume not loaded
+		return false
+	}
+}
+
+// makeRangeForLine creates an hcl.Range spanning an entire line (column 0 to end of line).
+// Editors will clamp the end column to the actual line length.
+func makeRangeForLine(filename string, line int) hcl.Range {
+	return hcl.Range{
+		Filename: filename,
+		Start: hcl.Pos{
+			Line:   line,
+			Column: 0,
+			Byte:   0,
+		},
+		End: hcl.Pos{
+			Line:   line,
+			Column: 9999,
+			Byte:   9999,
+		},
+	}
+}

--- a/internal/features/modules/jobs/validation.go
+++ b/internal/features/modules/jobs/validation.go
@@ -72,6 +72,22 @@ func SchemaModuleValidation(ctx context.Context, modStore *state.ModuleStore, ro
 		var fileDiags hcl.Diagnostics
 		fileDiags, rErr = moduleDecoder.ValidateFile(ctx, filename)
 
+		unloadedResult := validations.ModuleSchemaNotLoaded(modStore, rootFeature, modPath)
+
+		if ranges, ok := unloadedResult.UnloadedRanges[filename]; ok {
+			var filtered hcl.Diagnostics
+			for _, diag := range fileDiags {
+				if !validations.ShouldFilterDiagnostic(diag, ranges) {
+					filtered = append(filtered, diag)
+				}
+			}
+			fileDiags = filtered
+		}
+
+		if fileModuleDiags, ok := unloadedResult.Diagnostics[filename]; ok {
+			fileDiags = fileDiags.Extend(fileModuleDiags)
+		}
+
 		modDiags, ok := mod.ModuleDiagnostics[globalAst.SchemaValidationSource]
 		if !ok {
 			modDiags = make(ast.ModDiags)
@@ -86,6 +102,13 @@ func SchemaModuleValidation(ctx context.Context, modStore *state.ModuleStore, ro
 		// We validate the whole module, e.g. on open
 		var diags lang.DiagnosticsMap
 		diags, rErr = moduleDecoder.Validate(ctx)
+
+		unloadedResult := validations.ModuleSchemaNotLoaded(modStore, rootFeature, modPath)
+		diags = validations.FilterDiagnosticsForUnloadedModules(diags, unloadedResult.UnloadedRanges)
+
+		for file, fileDiags := range unloadedResult.Diagnostics {
+			diags[file] = diags[file].Extend(fileDiags)
+		}
 
 		sErr := modStore.UpdateModuleDiagnostics(modPath, globalAst.SchemaValidationSource, ast.ModDiagsFromMap(diags))
 		if sErr != nil {

--- a/internal/langserver/handlers/code_action.go
+++ b/internal/langserver/handlers/code_action.go
@@ -7,7 +7,8 @@ package handlers
 
 import (
 	"context"
-	"fmt"
+	"encoding/json"
+	"strings"
 
 	"github.com/opentofu/tofu-ls/internal/langserver/errors"
 	ilsp "github.com/opentofu/tofu-ls/internal/lsp"
@@ -28,10 +29,37 @@ func (svc *service) textDocumentCodeAction(ctx context.Context, params lsp.CodeA
 	var ca []lsp.CodeAction
 
 	// For action definitions, refer to https://code.visualstudio.com/api/references/vscode-api#CodeActionKind
-	// We only support format type code actions at the moment, and do not want to format without the client asking for
-	// them, so exit early here if nothing is requested.
+	dh := ilsp.HandleFromDocumentURI(params.TextDocument.URI)
+
+	// Always check for quickfix actions when there are diagnostics, even if no
+	// explicit request via Only
+	if len(params.Context.Diagnostics) > 0 {
+		for _, diag := range params.Context.Diagnostics {
+			// Check for "Module schema not loaded" warning to suggest "tofu init"
+			if diag.Severity == lsp.SeverityWarning &&
+				strings.HasPrefix(diag.Message, "Module schema not loaded") {
+				// Arguments must be in "key=value" string format
+				arg, err := json.Marshal("uri=" + dh.Dir.URI)
+				if err != nil {
+					continue
+				}
+				ca = append(ca, lsp.CodeAction{
+					Title:       "Run 'tofu init'",
+					Kind:        ilsp.QuickFixTofuInit,
+					Diagnostics: []lsp.Diagnostic{diag},
+					Command: &lsp.Command{
+						Title:     "Run 'tofu init'",
+						Command:   "tofu-ls.tofu.init",
+						Arguments: []json.RawMessage{arg},
+					},
+				})
+				break // Only add one action
+			}
+		}
+	}
+
+	// For source actions, require explicit request via Only
 	if len(params.Context.Only) == 0 {
-		svc.logger.Printf("No code action requested, exiting")
 		return ca, nil
 	}
 
@@ -41,13 +69,11 @@ func (svc *service) textDocumentCodeAction(ctx context.Context, params lsp.CodeA
 
 	wantedCodeActions := ilsp.SupportedCodeActions.Only(params.Context.Only)
 	if len(wantedCodeActions) == 0 {
-		return nil, fmt.Errorf("could not find a supported code action to execute for %s, wanted %v",
-			params.TextDocument.URI, params.Context.Only)
+		// No matching source actions, but we may have quickfix actions already
+		return ca, nil
 	}
 
 	svc.logger.Printf("Code actions supported: %v", wantedCodeActions)
-
-	dh := ilsp.HandleFromDocumentURI(params.TextDocument.URI)
 
 	doc, err := svc.stateStore.DocumentStore.GetDocument(dh)
 	if err != nil {

--- a/internal/langserver/handlers/command/handler.go
+++ b/internal/langserver/handlers/command/handler.go
@@ -10,12 +10,14 @@ import (
 
 	fmodules "github.com/opentofu/tofu-ls/internal/features/modules"
 	frootmodules "github.com/opentofu/tofu-ls/internal/features/rootmodules"
+	"github.com/opentofu/tofu-ls/internal/langserver/session"
 	"github.com/opentofu/tofu-ls/internal/state"
 )
 
 type CmdHandler struct {
 	StateStore *state.StateStore
 	Logger     *log.Logger
+	Server     session.Server
 	// TODO? Can features contribute commands, so we don't have to import
 	// the features here?
 	ModulesFeature     *fmodules.ModulesFeature

--- a/internal/langserver/handlers/command/init.go
+++ b/internal/langserver/handlers/command/init.go
@@ -25,7 +25,7 @@ func (h *CmdHandler) TofuInitHandler(ctx context.Context, args cmd.CommandArgs) 
 		return nil, err
 	}
 
-	dirHandle := document.DirHandleFromURI(*dirURI)
+	dirHandle := document.DirHandleFromURI(dirURI)
 	tfExec, err := module.TofuExecutorForModule(ctx, dirHandle.Path())
 	if err != nil {
 		return nil, errors.EnrichTfExecError(err)
@@ -58,15 +58,15 @@ func (h *CmdHandler) TofuInitHandler(ctx context.Context, args cmd.CommandArgs) 
 	return nil, nil
 }
 
-func validateURI(args cmd.CommandArgs) (*string, error) {
+func validateURI(args cmd.CommandArgs) (string, error) {
 	dirURI, ok := args.GetString("uri")
 	if !ok || dirURI == "" {
-		return nil, fmt.Errorf("%w: expected module uri argument to be set", jrpc2.InvalidParams.Err())
+		return "", fmt.Errorf("%w: expected module uri argument to be set", jrpc2.InvalidParams.Err())
 	}
 
 	if !uri.IsURIValid(dirURI) {
-		return nil, fmt.Errorf("URI %q is not valid", dirURI)
+		return "", fmt.Errorf("URI %q is not valid", dirURI)
 	}
 
-	return &dirURI, nil
+	return dirURI, nil
 }

--- a/internal/langserver/handlers/command/init.go
+++ b/internal/langserver/handlers/command/init.go
@@ -14,21 +14,18 @@ import (
 	"github.com/opentofu/tofu-ls/internal/langserver/cmd"
 	"github.com/opentofu/tofu-ls/internal/langserver/errors"
 	"github.com/opentofu/tofu-ls/internal/langserver/progress"
+	lsp "github.com/opentofu/tofu-ls/internal/protocol"
 	"github.com/opentofu/tofu-ls/internal/tofu/module"
 	"github.com/opentofu/tofu-ls/internal/uri"
 )
 
-func (h *CmdHandler) TofuInitHandler(ctx context.Context, args cmd.CommandArgs) (interface{}, error) {
-	dirUri, ok := args.GetString("uri")
-	if !ok || dirUri == "" {
-		return nil, fmt.Errorf("%w: expected module uri argument to be set", jrpc2.InvalidParams.Err())
+func (h *CmdHandler) TofuInitHandler(ctx context.Context, args cmd.CommandArgs) (any, error) {
+	dirURI, err := validateURI(args)
+	if err != nil {
+		return nil, err
 	}
 
-	if !uri.IsURIValid(dirUri) {
-		return nil, fmt.Errorf("URI %q is not valid", dirUri)
-	}
-
-	dirHandle := document.DirHandleFromURI(dirUri)
+	dirHandle := document.DirHandleFromURI(*dirURI)
 	tfExec, err := module.TofuExecutorForModule(ctx, dirHandle.Path())
 	if err != nil {
 		return nil, errors.EnrichTfExecError(err)
@@ -45,5 +42,31 @@ func (h *CmdHandler) TofuInitHandler(ctx context.Context, args cmd.CommandArgs) 
 		return nil, err
 	}
 
+	// Clear diagnostics for open documents in this module so stale warnings disappear, the next time the file is edited
+	// or saved, diagnostics will be re-computed.
+	if h.Server != nil && h.StateStore != nil {
+		docs, _ := h.StateStore.DocumentStore.OpenDocumentsForDir(dirHandle)
+		for _, doc := range docs {
+			docURI := doc.Dir.URI + "/" + doc.Filename
+			_ = h.Server.Notify(ctx, "textDocument/publishDiagnostics", lsp.PublishDiagnosticsParams{
+				URI:         lsp.DocumentURI(docURI),
+				Diagnostics: []lsp.Diagnostic{},
+			})
+		}
+	}
+
 	return nil, nil
+}
+
+func validateURI(args cmd.CommandArgs) (*string, error) {
+	dirURI, ok := args.GetString("uri")
+	if !ok || dirURI == "" {
+		return nil, fmt.Errorf("%w: expected module uri argument to be set", jrpc2.InvalidParams.Err())
+	}
+
+	if !uri.IsURIValid(dirURI) {
+		return nil, fmt.Errorf("URI %q is not valid", dirURI)
+	}
+
+	return &dirURI, nil
 }

--- a/internal/langserver/handlers/execute_command.go
+++ b/internal/langserver/handlers/execute_command.go
@@ -20,6 +20,7 @@ func cmdHandlers(svc *service) cmd.Handlers {
 	cmdHandler := &command.CmdHandler{
 		StateStore: svc.stateStore,
 		Logger:     svc.logger,
+		Server:     svc.server,
 	}
 	if svc.features != nil {
 		cmdHandler.ModulesFeature = svc.features.Modules

--- a/internal/langserver/handlers/handlers_test.go
+++ b/internal/langserver/handlers/handlers_test.go
@@ -53,7 +53,7 @@ func initializeResponse(t *testing.T, commandPrefix string) string {
 				"referencesProvider": true,
 				"documentSymbolProvider": true,
 				"codeActionProvider": {
-					"codeActionKinds": ["source.formatAll.opentofu"]
+					"codeActionKinds": ["quickfix.opentofu.init","source.formatAll.opentofu"]
 				},
 				"codeLensProvider": {},
 				"documentLinkProvider": {},

--- a/internal/lsp/code_actions.go
+++ b/internal/lsp/code_actions.go
@@ -14,6 +14,9 @@ import (
 const (
 	// SourceFormatAllTofu is a OpenTofu specific format code action.
 	SourceFormatAllTofu = "source.formatAll.opentofu"
+
+	// QuickFixTofuInit is a quick fix action to run tofu init.
+	QuickFixTofuInit = "quickfix.opentofu.init"
 )
 
 type CodeActions map[lsp.CodeActionKind]bool
@@ -37,6 +40,7 @@ var (
 	// files to be formatted, but not terraform files (or vice versa).
 	SupportedCodeActions = CodeActions{
 		SourceFormatAllTofu: true,
+		QuickFixTofuInit:    true,
 	}
 )
 

--- a/internal/state/documents.go
+++ b/internal/state/documents.go
@@ -200,3 +200,20 @@ func DirHasOpenDocuments(txn *memdb.Txn, dirHandle document.DirHandle) (bool, er
 
 	return obj != nil, nil
 }
+
+func (s *DocumentStore) OpenDocumentsForDir(dirHandle document.DirHandle) ([]*document.Document, error) {
+	txn := s.db.Txn(false)
+
+	it, err := txn.Get(documentsTableName, "dir", dirHandle)
+	if err != nil {
+		return nil, err
+	}
+
+	var docs []*document.Document
+	for obj := it.Next(); obj != nil; obj = it.Next() {
+		doc := obj.(*document.Document)
+		docs = append(docs, doc)
+	}
+
+	return docs, nil
+}


### PR DESCRIPTION
This PR handles situations where modules do not yet have their schema populated (ie, not known or initialized) and instead of saying that parameters are unexpected, it now prompts the user to run `tofu init`.

It also adds a quick code action for `tofu init` that will allow the user to run `tofu init` via tofu-ls if they want to.

Improves DX For: https://github.com/opentofu/vscode-opentofu/issues/122

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/tofu-ls/blob/main/.github/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
- [ ] If I'm releasing, I have read the [releasing guide](https://github.com/opentofu/tofu-ls/blob/main/.github/RELEASE.md).

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: -->

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
