### PR TITLE
Add underscore as a completion trigger character

### DIFF
--- a/internal/langserver/handlers/handlers_test.go
+++ b/internal/langserver/handlers/handlers_test.go
@@ -41,7 +41,7 @@ func initializeResponse(t *testing.T, commandPrefix string) string {
 					"save": {}
 				},
 				"completionProvider": {
-					"triggerCharacters": [".", "["],
+					"triggerCharacters": [".", "[", "_"],
 					"resolveProvider": true
 				},
 				"hoverProvider": true,

--- a/internal/langserver/handlers/initialize.go
+++ b/internal/langserver/handlers/initialize.go
@@ -177,7 +177,7 @@ func initializeResult(ctx context.Context) lsp.InitializeResult {
 			},
 			CompletionProvider: lsp.CompletionOptions{
 				ResolveProvider:   true,
-				TriggerCharacters: []string{".", "["},
+				TriggerCharacters: []string{".", "[", "_"},
 			},
 			CodeActionProvider: lsp.CodeActionOptions{
 				CodeActionKinds: ilsp.SupportedCodeActions.AsSlice(),


### PR DESCRIPTION
This allows editors to request completions easier when a end-user inputs "_" inside a resource type label for example, (e.g `resource "aws_`)

This improves the completion experience along with https://github.com/opentofu/hcl-lang/pull/2 to allow users to get improved completion when writing resources

<!-- If your PR resolves an issue, please add it here. -->
Resolves https://www.reddit.com/r/Terraform/comments/1r14jlr/help_with_terraformls_trigger_characters_andor/

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/tofu-ls/blob/main/.github/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
- [ ] If I'm releasing, I have read the [releasing guide](https://github.com/opentofu/tofu-ls/blob/main/.github/RELEASE.md).

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: -->

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
