### PR TITLE
fix: correct deltaStartChar after multiline tokens

### DIFF
--- a/internal/lsp/token_encoder.go
+++ b/internal/lsp/token_encoder.go
@@ -59,10 +59,11 @@ func (te *TokenEncoder) encodeTokenOfIndex(i int) []uint32 {
 	previousLine := 0
 	previousStartChar := 0
 	if i > 0 {
-		previousLine = te.Tokens[te.lastEncodedTokenIdx].Range.End.Line - 1
-		currentLine := te.Tokens[i].Range.End.Line - 1
-		if currentLine == previousLine {
-			previousStartChar = te.Tokens[te.lastEncodedTokenIdx].Range.Start.Column - 1
+		prevToken := te.Tokens[te.lastEncodedTokenIdx]
+		previousLine = prevToken.Range.End.Line - 1
+		currentLine := te.Tokens[i].Range.Start.Line - 1
+		if currentLine == previousLine && prevToken.Range.Start.Line == prevToken.Range.End.Line {
+			previousStartChar = prevToken.Range.Start.Column - 1
 		}
 	}
 

--- a/internal/lsp/token_encoder_test.go
+++ b/internal/lsp/token_encoder_test.go
@@ -230,6 +230,83 @@ func TestTokenEncoder_deltaStartCharBug(t *testing.T) {
 	}
 }
 
+func TestTokenEncoder_singleLineTokenAfterMultiLineToken(t *testing.T) {
+	// Simulates heredoc with two interpolations: the string between them
+	// is a multiline token, followed by a single-line token on the last line.
+	//
+	// locals {
+	//   test = <<-EOT
+	//     a: ${var.a}
+	//     b: ${var.b}
+	//   EOT
+	// }
+	bytes := []byte("locals {\n  test = <<-EOT\n    a: ${var.a}\n    b: ${var.b}\n  EOT\n}")
+	te := &TokenEncoder{
+		Lines: source.MakeSourceLines("test.tf", bytes),
+		Tokens: []lang.SemanticToken{
+			{
+				// "test" attr name
+				Type: lang.TokenAttrName,
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+					End:      hcl.Pos{Line: 2, Column: 7, Byte: 15},
+				},
+			},
+			{
+				// "var" in first interpolation
+				Type: lang.TokenReferenceStep,
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 3, Column: 11, Byte: 36},
+					End:      hcl.Pos{Line: 3, Column: 14, Byte: 39},
+				},
+			},
+			{
+				// String content between "}\n    b: ${" — spans two lines
+				Type: lang.TokenString,
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 3, Column: 16, Byte: 41},
+					End:      hcl.Pos{Line: 4, Column: 11, Byte: 56},
+				},
+			},
+			{
+				// "var" in second interpolation — on same line as end of multiline token
+				Type: lang.TokenReferenceStep,
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 4, Column: 11, Byte: 56},
+					End:      hcl.Pos{Line: 4, Column: 14, Byte: 59},
+				},
+			},
+		},
+		ClientCaps: protocol.SemanticTokensClientCapabilities{
+			TokenTypes:     serverTokenTypes.AsStrings(),
+			TokenModifiers: serverTokenModifiers.AsStrings(),
+		},
+	}
+	data := te.Encode()
+	expectedData := []uint32{
+		// "test" attr: line 1 (0-based), col 2, len 4
+		1, 2, 4, 9, 0,
+		// "var" ref: line 2, col 10, len 3
+		1, 10, 3, 18, 0,
+		// multiline string line 1: same line as prev, delta from col 10, len to EOL
+		0, 5, 15, 13, 0,
+		// multiline string line 2: next line, col 0, len 10
+		1, 0, 10, 13, 0,
+		// "var" ref: same line as end of multiline, col 10, len 3
+		// deltaStartChar must be relative to 0 (last emitted entry started at col 0)
+		0, 10, 3, 18, 0,
+	}
+
+	if diff := cmp.Diff(expectedData, data); diff != "" {
+		t.Fatalf("unexpected encoded data.\nexpected: %#v\ngiven:    %#v",
+			expectedData, data)
+	}
+}
+
 func TestTokenEncoder_tokenModifiers(t *testing.T) {
 	bytes := []byte(`myblock "mytype" {
   str_attr = "something"


### PR DESCRIPTION
## Summary

- Fixes semantic token encoding bug where `deltaStartChar` overflowed to ~4 billion (`uint32` wrap of a negative value) when a single-line token followed a multiline token on its last line
- Root cause: encoder used `Start.Column` of the previous multiline token (on a different line) instead of 0 (the column of the last emitted entry)
- This caused neovim to infinite loop at 100% CPU in `str_utfindex` processing the invalid offset

## Reproduction

Any `.tf` file with a heredoc containing 2+ interpolations, in a `tofu init`'d directory:

```hcl
variable "a" { default = "hello" }
variable "b" { default = "world" }
locals {
  test = <<-EOT
    a: ${var.a}
    b: ${var.b}
  EOT
}
```

## Test plan

- [x] Added `TestTokenEncoder_singleLineTokenAfterMultiLineToken` — verifies correct delta encoding when a single-line token follows a multiline token
- [x] All 359 existing tests pass
- [x] Verified fix resolves the neovim hang with the MRE above

Fixes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)