### PR TITLE
Semantic token should not break neovim when heredoc used

### DIFF
--- a/internal/langserver/handlers/semantic_tokens.go
+++ b/internal/langserver/handlers/semantic_tokens.go
@@ -7,8 +7,6 @@ package handlers
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
 	"github.com/creachadair/jrpc2"
 	ilsp "github.com/opentofu/tofu-ls/internal/lsp"
@@ -56,25 +54,6 @@ func (svc *service) TextDocumentSemanticTokensFull(ctx context.Context, params l
 		return tks, err
 	}
 
-	// TODO remove this once finished. Meant only for debugging
-	var b strings.Builder
-	for _, token := range tokens {
-		var mods []string
-		for _, modifier := range token.Modifiers {
-			mods = append(mods, string(modifier))
-		}
-		b.WriteString(fmt.Sprintf("%s; mod: %s; rangeStart: %d-%d-%d; rangeEnd: %d-%d-%d ### ",
-			token.Type,
-			strings.Join(mods, " "),
-			token.Range.Start.Line,
-			token.Range.Start.Column,
-			token.Range.Start.Byte,
-			token.Range.End.Line,
-			token.Range.End.Column,
-			token.Range.End.Byte,
-		))
-	}
-	svc.logger.Println(b.String())
 	te := &ilsp.TokenEncoder{
 		Lines:      doc.Lines,
 		Tokens:     tokens,

--- a/internal/langserver/handlers/semantic_tokens.go
+++ b/internal/langserver/handlers/semantic_tokens.go
@@ -7,6 +7,8 @@ package handlers
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/creachadair/jrpc2"
 	ilsp "github.com/opentofu/tofu-ls/internal/lsp"
@@ -54,6 +56,25 @@ func (svc *service) TextDocumentSemanticTokensFull(ctx context.Context, params l
 		return tks, err
 	}
 
+	// TODO remove this once finished. Meant only for debugging
+	var b strings.Builder
+	for _, token := range tokens {
+		var mods []string
+		for _, modifier := range token.Modifiers {
+			mods = append(mods, string(modifier))
+		}
+		b.WriteString(fmt.Sprintf("%s; mod: %s; rangeStart: %d-%d-%d; rangeEnd: %d-%d-%d ### ",
+			token.Type,
+			strings.Join(mods, " "),
+			token.Range.Start.Line,
+			token.Range.Start.Column,
+			token.Range.Start.Byte,
+			token.Range.End.Line,
+			token.Range.End.Column,
+			token.Range.End.Byte,
+		))
+	}
+	svc.logger.Println(b.String())
 	te := &ilsp.TokenEncoder{
 		Lines:      doc.Lines,
 		Tokens:     tokens,

--- a/internal/lsp/token_encoder.go
+++ b/internal/lsp/token_encoder.go
@@ -59,9 +59,17 @@ func (te *TokenEncoder) encodeTokenOfIndex(i int) []uint32 {
 	previousLine := 0
 	previousStartChar := 0
 	if i > 0 {
+		previousTokenStartLine := te.Tokens[te.lastEncodedTokenIdx].Range.Start.Line - 1
 		previousLine = te.Tokens[te.lastEncodedTokenIdx].Range.End.Line - 1
 		currentLine := te.Tokens[i].Range.End.Line - 1
-		if currentLine == previousLine {
+		// If the previous token started on a line and ended on another one, there is a good chance
+		// to be inside a heredoc string which contains also different types of tokens (eg: references).
+		// If that happens, it's safe to assume that the previousStartChar is 0
+		// since the previous token "continued" from one line to another, making the start of the current line also the
+		// start of the previous token.
+		// But if both, the previous token (its start and end) and the current token are on the same line, we want
+		// to use the previous token start marker to be able to correctly indicate the current token deltaStartChar.
+		if currentLine == previousLine && previousTokenStartLine == previousLine {
 			previousStartChar = te.Tokens[te.lastEncodedTokenIdx].Range.Start.Column - 1
 		}
 	}

--- a/internal/lsp/token_encoder_test.go
+++ b/internal/lsp/token_encoder_test.go
@@ -386,168 +386,133 @@ func TestTokenEncoder_unsupported(t *testing.T) {
 	}
 }
 
-func TestTokenEncoder_multiLineTokensWithChildTokens(t *testing.T) {
+func TestTokenEncoder_multiLineLocalWithInnerTokens(t *testing.T) {
 	// Reproduces https://github.com/opentofu/tofu-ls/issues/156
-	bytes := []byte(`variable "a" {
-  default = "hello"
-}
-
-variable "b" {
-  default = "world"
-}
-
-locals {
+	bytes := []byte(`locals {
+  a    = "test"
   test = <<-EOT
-    a: ${var.a}
-    b: ${var.b}
+    x: ${local.a}
+    y: ${local.a}
   EOT
-}`)
+}
+`)
 	// The TokenEncoder configured here simulates the result that the handlers/semantic_token.go would generate.
 	te := &TokenEncoder{
 		Lines: source.MakeSourceLines("test.tf", bytes),
 		Tokens: []lang.SemanticToken{
 			{
+				// The start of the locals block: locals
 				Type:      lang.TokenBlockType,
-				Modifiers: lang.SemanticTokenModifiers{lang.SemanticTokenModifier("opentofu-variable")},
+				Modifiers: lang.SemanticTokenModifiers{lang.SemanticTokenModifier("opentofu-locals")},
 				Range: hcl.Range{
 					Filename: "test.tf",
 					Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
-					End:      hcl.Pos{Line: 1, Column: 9, Byte: 8},
+					End:      hcl.Pos{Line: 1, Column: 7, Byte: 6},
 				},
 			},
 			{
-				Type:      lang.TokenBlockLabel,
-				Modifiers: lang.SemanticTokenModifiers{lang.SemanticTokenModifier("opentofu-variable")},
-				Range: hcl.Range{
-					Filename: "test.tf",
-					Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
-					End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
-				},
-			},
-			{
-				Type:      lang.TokenAttrName,
-				Modifiers: lang.SemanticTokenModifiers{lang.SemanticTokenModifier("opentofu-variable")},
-				Range: hcl.Range{
-					Filename: "test.tf",
-					Start:    hcl.Pos{Line: 2, Column: 3, Byte: 17},
-					End:      hcl.Pos{Line: 2, Column: 10, Byte: 24},
-				},
-			},
-			{
-				Type: lang.TokenString,
-				Range: hcl.Range{
-					Filename: "test.tf",
-					Start:    hcl.Pos{Line: 2, Column: 13, Byte: 27},
-					End:      hcl.Pos{Line: 2, Column: 20, Byte: 34},
-				},
-			},
-			{
-				Type:      lang.TokenBlockType,
-				Modifiers: lang.SemanticTokenModifiers{lang.SemanticTokenModifier("opentofu-variable")},
-				Range: hcl.Range{
-					Filename: "test.tf",
-					Start:    hcl.Pos{Line: 5, Column: 1, Byte: 38},
-					End:      hcl.Pos{Line: 5, Column: 9, Byte: 46},
-				},
-			},
-			{
-				Type:      lang.TokenBlockLabel,
-				Modifiers: lang.SemanticTokenModifiers{lang.SemanticTokenModifier("opentofu-variable")},
-				Range: hcl.Range{
-					Filename: "test.tf",
-					Start:    hcl.Pos{Line: 5, Column: 10, Byte: 47},
-					End:      hcl.Pos{Line: 5, Column: 13, Byte: 50},
-				},
-			},
-			{
-				Type:      lang.TokenAttrName,
-				Modifiers: lang.SemanticTokenModifiers{lang.SemanticTokenModifier("opentofu-variable")},
-				Range: hcl.Range{
-					Filename: "test.tf",
-					Start:    hcl.Pos{Line: 6, Column: 3, Byte: 55},
-					End:      hcl.Pos{Line: 6, Column: 10, Byte: 62},
-				},
-			},
-			{
-				Type: lang.TokenString,
-				Range: hcl.Range{
-					Filename: "test.tf",
-					Start:    hcl.Pos{Line: 6, Column: 13, Byte: 65},
-					End:      hcl.Pos{Line: 6, Column: 20, Byte: 72},
-				},
-			},
-			{
-				Type:      lang.TokenBlockType,
-				Modifiers: lang.SemanticTokenModifiers{lang.SemanticTokenModifier("opentofu-locals")},
-				Range: hcl.Range{
-					Filename: "test.tf",
-					Start:    hcl.Pos{Line: 9, Column: 1, Byte: 76},
-					End:      hcl.Pos{Line: 9, Column: 7, Byte: 82},
-				},
-			},
-			{
+				// The first local name: a
 				Type:      lang.TokenAttrName,
 				Modifiers: lang.SemanticTokenModifiers{lang.SemanticTokenModifier("opentofu-locals")},
 				Range: hcl.Range{
 					Filename: "test.tf",
-					Start:    hcl.Pos{Line: 10, Column: 3, Byte: 87},
-					End:      hcl.Pos{Line: 10, Column: 7, Byte: 91},
+					Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+					End:      hcl.Pos{Line: 2, Column: 4, Byte: 12},
 				},
 			},
 			{
+				// The value of the first local: "test"
 				Type: lang.TokenString,
 				Range: hcl.Range{
 					Filename: "test.tf",
-					Start:    hcl.Pos{Line: 11, Column: 5, Byte: 105},
-					End:      hcl.Pos{Line: 11, Column: 8, Byte: 108},
+					Start:    hcl.Pos{Line: 2, Column: 10, Byte: 18},
+					End:      hcl.Pos{Line: 2, Column: 16, Byte: 24},
 				},
 			},
 			{
-				Type: lang.TokenReferenceStep,
+				// The second local name: test
+				Type:      lang.TokenAttrName,
+				Modifiers: lang.SemanticTokenModifiers{lang.SemanticTokenModifier("opentofu-locals")},
 				Range: hcl.Range{
 					Filename: "test.tf",
-					Start:    hcl.Pos{Line: 11, Column: 10, Byte: 110},
-					End:      hcl.Pos{Line: 11, Column: 13, Byte: 113},
+					Start:    hcl.Pos{Line: 3, Column: 3, Byte: 27},
+					End:      hcl.Pos{Line: 3, Column: 7, Byte: 31},
 				},
 			},
 			{
-				Type: lang.TokenReferenceStep,
-				Range: hcl.Range{
-					Filename: "test.tf",
-					Start:    hcl.Pos{Line: 11, Column: 14, Byte: 114},
-					End:      hcl.Pos{Line: 11, Column: 15, Byte: 115},
-				},
-			},
-			{
+				// The name of the first multiline variable: "x: "
 				Type: lang.TokenString,
 				Range: hcl.Range{
 					Filename: "test.tf",
-					Start:    hcl.Pos{Line: 11, Column: 16, Byte: 116},
-					End:      hcl.Pos{Line: 12, Column: 8, Byte: 124},
+					Start:    hcl.Pos{Line: 4, Column: 5, Byte: 45},
+					End:      hcl.Pos{Line: 4, Column: 8, Byte: 48},
 				},
 			},
 			{
+				// Reference to the locals namespace: local
 				Type: lang.TokenReferenceStep,
 				Range: hcl.Range{
 					Filename: "test.tf",
-					Start:    hcl.Pos{Line: 12, Column: 10, Byte: 126},
-					End:      hcl.Pos{Line: 12, Column: 13, Byte: 129},
+					Start:    hcl.Pos{Line: 4, Column: 10, Byte: 50},
+					End:      hcl.Pos{Line: 4, Column: 15, Byte: 55},
 				},
 			},
 			{
+				// Reference to the first local name: a
 				Type: lang.TokenReferenceStep,
 				Range: hcl.Range{
 					Filename: "test.tf",
-					Start:    hcl.Pos{Line: 12, Column: 14, Byte: 130},
-					End:      hcl.Pos{Line: 12, Column: 15, Byte: 131},
+					Start:    hcl.Pos{Line: 4, Column: 16, Byte: 56},
+					End:      hcl.Pos{Line: 4, Column: 17, Byte: 57},
 				},
 			},
 			{
+				// The name of the second multiline variable. Since this is a multiline string, the start line of this token is different
+				// from the end line so this ends right after the first variable inside the heredoc and ends before the next reference
+				// to the "locals" namespace.
+				// Start indicated by "[" and stop by "]":
+				// test = <<-EOT
+				//  x: ${local.a}[
+				//  y: ${]local.a}
+				// EOT
 				Type: lang.TokenString,
 				Range: hcl.Range{
 					Filename: "test.tf",
-					Start:    hcl.Pos{Line: 12, Column: 16, Byte: 132},
-					End:      hcl.Pos{Line: 13, Column: 1, Byte: 133},
+					Start:    hcl.Pos{Line: 4, Column: 18, Byte: 58},
+					End:      hcl.Pos{Line: 5, Column: 8, Byte: 66},
+				},
+			},
+			{
+				// Reference to the locals namespace: local
+				Type: lang.TokenReferenceStep,
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 5, Column: 10, Byte: 68},
+					End:      hcl.Pos{Line: 5, Column: 15, Byte: 73},
+				},
+			},
+			{
+				// Reference to the first local name: a
+				Type: lang.TokenReferenceStep,
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 5, Column: 16, Byte: 74},
+					End:      hcl.Pos{Line: 5, Column: 17, Byte: 75},
+				},
+			},
+			{
+				// The remainder of the heredoc bytes. Since this is a multiline string, the start line of this token is different
+				// from the end line so this ends right after the second variable inside the heredoc and ends the heredoc ending
+				// Start indicated by "[" and stop by "]":
+				// test = <<-EOT
+				//  x: ${local.a}
+				//  y: ${local.a[}
+				// ]EOT
+				Type: lang.TokenString,
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 5, Column: 18, Byte: 76},
+					End:      hcl.Pos{Line: 6, Column: 1, Byte: 77},
 				},
 			},
 		},
@@ -559,33 +524,27 @@ locals {
 	data := te.Encode()
 
 	noModMask := uint32(TokenModifiersLegend(serverTokenModifiers.AsStrings()).BitMask(semtok.TokenModifiers{}))
-	varModMask := uint32(TokenModifiersLegend(serverTokenModifiers.AsStrings()).BitMask(semtok.TokenModifiers{"opentofu-variable"}))
 	localsModMask := uint32(TokenModifiersLegend(serverTokenModifiers.AsStrings()).BitMask(semtok.TokenModifiers{"opentofu-locals"}))
 	blockTypeIdx := uint32(TokenTypesLegend(serverTokenTypes.AsStrings()).Index(semtok.TokenType(lang.TokenBlockType)))
-	blockLabelIdx := uint32(TokenTypesLegend(serverTokenTypes.AsStrings()).Index(semtok.TokenType(lang.TokenBlockLabel)))
 	attrNameIdx := uint32(TokenTypesLegend(serverTokenTypes.AsStrings()).Index(semtok.TokenType(lang.TokenAttrName)))
 	strIdx := uint32(TokenTypesLegend(serverTokenTypes.AsStrings()).Index(semtok.TokenType(lang.TokenString)))
 	refIdx := uint32(TokenTypesLegend(serverTokenTypes.AsStrings()).Index(semtok.TokenType(lang.TokenReferenceStep)))
 
 	expectedData := []uint32{
-		0, 0, 8, blockTypeIdx, varModMask,
-		0, 9, 3, blockLabelIdx, varModMask,
-		1, 2, 7, attrNameIdx, varModMask,
-		0, 10, 7, strIdx, noModMask,
-		3, 0, 8, blockTypeIdx, varModMask,
-		0, 9, 3, blockLabelIdx, varModMask,
-		1, 2, 7, attrNameIdx, varModMask,
-		0, 10, 7, strIdx, noModMask,
-		3, 0, 6, blockTypeIdx, localsModMask,
+		0, 0, 6, blockTypeIdx, localsModMask,
+		1, 2, 1, attrNameIdx, localsModMask,
+		0, 7, 6, strIdx, noModMask,
 		1, 2, 4, attrNameIdx, localsModMask,
 		1, 4, 3, strIdx, noModMask,
-		0, 5, 3, refIdx, noModMask,
-		0, 4, 1, refIdx, noModMask,
-		0, 15, 15, strIdx, noModMask,
+		0, 5, 5, refIdx, noModMask,
+		0, 6, 1, refIdx, noModMask,
+		0, 17, 17, strIdx, noModMask,
 		1, 0, 7, strIdx, noModMask,
-		0, 4294967290, 3, refIdx, noModMask,
-		0, 4, 1, refIdx, noModMask,
-		0, 15, 15, strIdx, noModMask,
+		0, 9, 5, refIdx, noModMask,
+		// ^ The issue was here. The deltaStartChar (2nd value) was negative making neovim (>=0.12.0) running in an infinit loop.
+		// See the source code changed in the same commit with the addition of this test for more details
+		0, 6, 1, refIdx, noModMask,
+		0, 17, 17, strIdx, noModMask,
 		1, 0, 0, strIdx, noModMask,
 	}
 

--- a/internal/lsp/token_encoder_test.go
+++ b/internal/lsp/token_encoder_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/opentofu/tofu-ls/internal/lsp/semtok"
 	"github.com/opentofu/tofu-ls/internal/protocol"
 	"github.com/opentofu/tofu-ls/internal/source"
 )
@@ -382,5 +383,214 @@ func TestTokenEncoder_unsupported(t *testing.T) {
 	if diff := cmp.Diff(expectedData, data); diff != "" {
 		t.Fatalf("unexpected encoded data.\nexpected: %#v\ngiven:    %#v",
 			expectedData, data)
+	}
+}
+
+func TestTokenEncoder_multiLineTokensWithChildTokens(t *testing.T) {
+	// Reproduces https://github.com/opentofu/tofu-ls/issues/156
+	bytes := []byte(`variable "a" {
+  default = "hello"
+}
+
+variable "b" {
+  default = "world"
+}
+
+locals {
+  test = <<-EOT
+    a: ${var.a}
+    b: ${var.b}
+  EOT
+}`)
+	// The TokenEncoder configured here simulates the result that the handlers/semantic_token.go would generate.
+	te := &TokenEncoder{
+		Lines: source.MakeSourceLines("test.tf", bytes),
+		Tokens: []lang.SemanticToken{
+			{
+				Type:      lang.TokenBlockType,
+				Modifiers: lang.SemanticTokenModifiers{lang.SemanticTokenModifier("opentofu-variable")},
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+					End:      hcl.Pos{Line: 1, Column: 9, Byte: 8},
+				},
+			},
+			{
+				Type:      lang.TokenBlockLabel,
+				Modifiers: lang.SemanticTokenModifiers{lang.SemanticTokenModifier("opentofu-variable")},
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+					End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+				},
+			},
+			{
+				Type:      lang.TokenAttrName,
+				Modifiers: lang.SemanticTokenModifiers{lang.SemanticTokenModifier("opentofu-variable")},
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 2, Column: 3, Byte: 17},
+					End:      hcl.Pos{Line: 2, Column: 10, Byte: 24},
+				},
+			},
+			{
+				Type: lang.TokenString,
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 2, Column: 13, Byte: 27},
+					End:      hcl.Pos{Line: 2, Column: 20, Byte: 34},
+				},
+			},
+			{
+				Type:      lang.TokenBlockType,
+				Modifiers: lang.SemanticTokenModifiers{lang.SemanticTokenModifier("opentofu-variable")},
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 5, Column: 1, Byte: 38},
+					End:      hcl.Pos{Line: 5, Column: 9, Byte: 46},
+				},
+			},
+			{
+				Type:      lang.TokenBlockLabel,
+				Modifiers: lang.SemanticTokenModifiers{lang.SemanticTokenModifier("opentofu-variable")},
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 5, Column: 10, Byte: 47},
+					End:      hcl.Pos{Line: 5, Column: 13, Byte: 50},
+				},
+			},
+			{
+				Type:      lang.TokenAttrName,
+				Modifiers: lang.SemanticTokenModifiers{lang.SemanticTokenModifier("opentofu-variable")},
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 6, Column: 3, Byte: 55},
+					End:      hcl.Pos{Line: 6, Column: 10, Byte: 62},
+				},
+			},
+			{
+				Type: lang.TokenString,
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 6, Column: 13, Byte: 65},
+					End:      hcl.Pos{Line: 6, Column: 20, Byte: 72},
+				},
+			},
+			{
+				Type:      lang.TokenBlockType,
+				Modifiers: lang.SemanticTokenModifiers{lang.SemanticTokenModifier("opentofu-locals")},
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 9, Column: 1, Byte: 76},
+					End:      hcl.Pos{Line: 9, Column: 7, Byte: 82},
+				},
+			},
+			{
+				Type:      lang.TokenAttrName,
+				Modifiers: lang.SemanticTokenModifiers{lang.SemanticTokenModifier("opentofu-locals")},
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 10, Column: 3, Byte: 87},
+					End:      hcl.Pos{Line: 10, Column: 7, Byte: 91},
+				},
+			},
+			{
+				Type: lang.TokenString,
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 11, Column: 5, Byte: 105},
+					End:      hcl.Pos{Line: 11, Column: 8, Byte: 108},
+				},
+			},
+			{
+				Type: lang.TokenReferenceStep,
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 11, Column: 10, Byte: 110},
+					End:      hcl.Pos{Line: 11, Column: 13, Byte: 113},
+				},
+			},
+			{
+				Type: lang.TokenReferenceStep,
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 11, Column: 14, Byte: 114},
+					End:      hcl.Pos{Line: 11, Column: 15, Byte: 115},
+				},
+			},
+			{
+				Type: lang.TokenString,
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 11, Column: 16, Byte: 116},
+					End:      hcl.Pos{Line: 12, Column: 8, Byte: 124},
+				},
+			},
+			{
+				Type: lang.TokenReferenceStep,
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 12, Column: 10, Byte: 126},
+					End:      hcl.Pos{Line: 12, Column: 13, Byte: 129},
+				},
+			},
+			{
+				Type: lang.TokenReferenceStep,
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 12, Column: 14, Byte: 130},
+					End:      hcl.Pos{Line: 12, Column: 15, Byte: 131},
+				},
+			},
+			{
+				Type: lang.TokenString,
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 12, Column: 16, Byte: 132},
+					End:      hcl.Pos{Line: 13, Column: 1, Byte: 133},
+				},
+			},
+		},
+		ClientCaps: protocol.SemanticTokensClientCapabilities{
+			TokenTypes:     serverTokenTypes.AsStrings(),
+			TokenModifiers: serverTokenModifiers.AsStrings(),
+		},
+	}
+	data := te.Encode()
+
+	noModMask := uint32(TokenModifiersLegend(serverTokenModifiers.AsStrings()).BitMask(semtok.TokenModifiers{}))
+	varModMask := uint32(TokenModifiersLegend(serverTokenModifiers.AsStrings()).BitMask(semtok.TokenModifiers{"opentofu-variable"}))
+	localsModMask := uint32(TokenModifiersLegend(serverTokenModifiers.AsStrings()).BitMask(semtok.TokenModifiers{"opentofu-locals"}))
+	blockTypeIdx := uint32(TokenTypesLegend(serverTokenTypes.AsStrings()).Index(semtok.TokenType(lang.TokenBlockType)))
+	blockLabelIdx := uint32(TokenTypesLegend(serverTokenTypes.AsStrings()).Index(semtok.TokenType(lang.TokenBlockLabel)))
+	attrNameIdx := uint32(TokenTypesLegend(serverTokenTypes.AsStrings()).Index(semtok.TokenType(lang.TokenAttrName)))
+	strIdx := uint32(TokenTypesLegend(serverTokenTypes.AsStrings()).Index(semtok.TokenType(lang.TokenString)))
+	refIdx := uint32(TokenTypesLegend(serverTokenTypes.AsStrings()).Index(semtok.TokenType(lang.TokenReferenceStep)))
+
+	expectedData := []uint32{
+		0, 0, 8, blockTypeIdx, varModMask,
+		0, 9, 3, blockLabelIdx, varModMask,
+		1, 2, 7, attrNameIdx, varModMask,
+		0, 10, 7, strIdx, noModMask,
+		3, 0, 8, blockTypeIdx, varModMask,
+		0, 9, 3, blockLabelIdx, varModMask,
+		1, 2, 7, attrNameIdx, varModMask,
+		0, 10, 7, strIdx, noModMask,
+		3, 0, 6, blockTypeIdx, localsModMask,
+		1, 2, 4, attrNameIdx, localsModMask,
+		1, 4, 3, strIdx, noModMask,
+		0, 5, 3, refIdx, noModMask,
+		0, 4, 1, refIdx, noModMask,
+		0, 15, 15, strIdx, noModMask,
+		1, 0, 7, strIdx, noModMask,
+		0, 4294967290, 3, refIdx, noModMask,
+		0, 4, 1, refIdx, noModMask,
+		0, 15, 15, strIdx, noModMask,
+		1, 0, 0, strIdx, noModMask,
+	}
+
+	if diff := cmp.Diff(expectedData, data); diff != "" {
+		t.Fatalf("unexpected encoded data.\nexpected: %#v\ngiven:    %#v\ndiff: %s",
+			expectedData, data, diff)
 	}
 }


### PR DESCRIPTION
Resolves #156

TL;DR: This bug was caused by how the `start` of the previous token was calculated. If the _currently processed token_ is on the same line with the end of the _previous token_ and the previous token spans on multiple lines, then the `start` of the previous token is clearly 0 (relative to the current line on which the current token resides).

---

_There are plenty of details in the resolved issue for whoever wants to dig more into the investigation of this. Here, I will describe mostly the thinking process involved in providing the current fix._

First (dumb) approach was to handle the `deltaStartChar` individually, meaning that if it was smaller than 0, that would be set to 0 instead to be sure that we don't break the client (neovim >=0.12.0). The fix looked something like this:
<img width="695" height="669" alt="Screenshot 2026-04-22 at 17 52 16" src="https://github.com/user-attachments/assets/d3bf624c-5c74-43d0-9a5e-f6f13091652d" />

Testing the previous fix, decided to go for a more minimal example in the added unit test which made me look more [into the LSP specs](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_semanticTokens), and caught my attention this part:
> at index 5*i - deltaLine: token line number, relative to the start of the previous token
> at index 5*i+1 - deltaStart: token start character, relative to the start of the previous token (**relative to 0 or the previous token’s start if they are on the same line**)
> ...

Therefore, if the previous token (previous to the currently processed one) spans multiple lines, it's quite clear that if the current token is on the same line with the previous one, the start character of the previous token is 0.

It took me a while to get to this point, but for me, this makes total sense.
Please let me know if you disagree with the conclusion.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/tofu-ls/blob/main/.github/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
- [x] If I'm releasing, I have read the [releasing guide](https://github.com/opentofu/tofu-ls/blob/main/.github/RELEASE.md).

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: -->

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
